### PR TITLE
Add vscode configuration

### DIFF
--- a/.vscode/cmake-kits.json
+++ b/.vscode/cmake-kits.json
@@ -1,0 +1,9 @@
+[
+    {
+        "name": "Local_gcc-avr-none-eabi",
+        "toolchainFile": "${workspaceFolder}/cmake/AnyAvrGcc.cmake",
+        "cmakeSettings": {
+            "CMAKE_MAKE_PROGRAM": "${workspaceFolder}/.dependencies/ninja-1.9.0/ninja"
+        }
+    }
+]

--- a/.vscode/cmake-variants.yaml
+++ b/.vscode/cmake-variants.yaml
@@ -1,0 +1,11 @@
+buildType:
+  default: debug
+  choices:
+    debug:
+      short: Debug
+      long: Emit debug information
+      buildType: Debug
+    release:
+      short: Release
+      long: Optimize generated code
+      buildType: Release

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+    "cmake.configureOnOpen": true,
+    "ccls.misc.compilationDatabaseDirectory": "build-vscode",
+    "ccls.index.multiVersion": 1,
+    "ccls.clang.extraArgs": [
+        "-fno-ms-compatibility",
+        "-nostdinc",
+        "-nostdinc++",
+        "-isystem${workspaceFolder}/.dependencies/avr8-gnu-toolchain-5.4.0/avr/include",
+        "-isystem${workspaceFolder}/.dependencies/avr8-gnu-toolchain-5.4.0/avr/include/avr",
+        "-isystem${workspaceFolder}/.dependencies/avr8-gnu-toolchain-5.4.0/avr/include/compat,
+        "-isystem${workspaceFolder}/.dependencies/avr8-gnu-toolchain-5.4.0/avr/include/sys",
+        "-isystem${workspaceFolder}/.dependencies/avr8-gnu-toolchain-5.4.0/avr/include/util",
+    ],
+    "cmake.buildDirectory": "${workspaceFolder}/build-vscode/${buildKit}",
+    "cmake.cmakePath": "${workspaceFolder}/.dependencies/cmake-3.15.5/bin/cmake",
+    "cmake.generator": "Ninja",
+    "files.insertFinalNewline": true,
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,7 +70,7 @@ void setup() {
     cpu::Init();
 
     shr16::shr16.Init();
-    leds.SetMode(4, false, modules::leds::Mode::blink0);
+    leds.SetMode(4, modules::leds::Color::green, modules::leds::Mode::blink0);
     leds.Step(0);
 
     // @@TODO if the shift register doesn't work we really can't signalize anything, only internal variables will be accessible if the UART works
@@ -81,7 +81,7 @@ void setup() {
         .baudrate = 115200,
     };
     hal::usart::usart1.Init(&usart_conf);
-    leds.SetMode(3, false, modules::leds::Mode::on);
+    leds.SetMode(3, modules::leds::Color::green, modules::leds::Mode::on);
     leds.Step(0);
 
     // @@TODO if both shift register and the UART are dead, we are sitting ducks :(
@@ -96,15 +96,15 @@ void setup() {
         .cpol = 1,
     };
     spi::Init(SPI0, &spi_conf);
-    leds.SetMode(2, false, modules::leds::Mode::on);
+    leds.SetMode(2, modules::leds::Color::green, modules::leds::Mode::on);
     leds.Step(0);
 
     // tmc::Init()
-    leds.SetMode(1, false, modules::leds::Mode::on);
+    leds.SetMode(1, modules::leds::Color::green, modules::leds::Mode::on);
     leds.Step(0);
 
     // adc::Init();
-    leds.SetMode(0, false, modules::leds::Mode::on);
+    leds.SetMode(0, modules::leds::Color::green, modules::leds::Mode::on);
     leds.Step(0);
 }
 


### PR DESCRIPTION
... to allow easier switching among firmware and unit tests

Firmware and tests now have a separate build directory which solves the CMAKE_SYSTEM_NAME issue we had earlier.

After switching to native gcc on a PC, the first configuration of the project still tries to build all, but that looks like a "feature" of vscode, not a bug in the cmake project configuration, but we may improve that in the future as well. 

The firmware build in this mode fails obviously, but the tests are then finally accessible.

MMU-22