### PR TITLE
Fix usart not working

### DIFF
--- a/src/hal/avr/usart.cpp
+++ b/src/hal/avr/usart.cpp
@@ -4,7 +4,7 @@
 namespace hal {
 namespace usart {
 
-USART usart1;
+USART usart1(USART1);
 
 uint8_t USART::Read() {
     uint8_t c = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -278,6 +278,7 @@ void loop() {
 
 int main() {
     setup();
+    sei(); ///enable interrupts
     for (;;) {
         loop();
     }


### PR DESCRIPTION
Usart IO base pointer wasn't initialized for some reason. Not sure when it broke to be honest.
Enabling interrupts between setup and loop.

MMU-6
MMU-13