### PR TITLE
Remove invalid/useless test sizeof(ptr) == 4

### DIFF
--- a/tests/unit/system_test.cpp
+++ b/tests/unit/system_test.cpp
@@ -2,5 +2,4 @@
 
 TEST_CASE("type tests", "[system]") {
     REQUIRE(sizeof(uint64_t) == 8);
-    REQUIRE(sizeof(char *) == 4);
 }


### PR DESCRIPTION
This test is currently valid only for 32bit architectures.

There doesn't seem to be a true reason for this test to
ensure a pointer is exactly 4 bytes, so remove the test.