### PR TITLE
Shim <limits> on AVR

### DIFF
--- a/src/hal/circular_buffer.h
+++ b/src/hal/circular_buffer.h
@@ -1,10 +1,6 @@
 #pragma once
-
-#include <stdint.h>
 #include <stddef.h>
-#ifndef __AVR__
-#include <limits>
-#endif
+#include "../limits.h"
 
 /// A generic circular index class which can be used to build circular buffers
 /// Can hold up to size elements
@@ -15,10 +11,8 @@
 template <typename index_t = uint_fast8_t, index_t size = 16>
 class CircularIndex {
 public:
-#ifndef __AVR__
     static_assert(size <= std::numeric_limits<index_t>::max() / 2,
         "index_t is too small for the requested size");
-#endif
 
     constexpr inline CircularIndex()
         : tail(0)

--- a/src/limits.h
+++ b/src/limits.h
@@ -1,0 +1,23 @@
+#pragma once
+#ifndef __AVR__
+#include <limits>
+#else
+
+// A minimal std::numeric_limits for platforms that lack one
+#include <stddef.h>
+#include <stdint.h>
+
+namespace std {
+
+template <typename T>
+class numeric_limits;
+
+template <>
+class numeric_limits<uint8_t> {
+public:
+    static constexpr size_t max() { return UINT8_MAX; }
+};
+
+} // namespace std
+
+#endif


### PR DESCRIPTION
Instead of adding #ifdefs for missing headers, create a shim that can be included everywhere.

"limits.h" includes a bare-bone implementation of numeric_limits (to be extended as needed).