### PR TITLE
GPIO fixes

### DIFF
--- a/src/hal/gpio.h
+++ b/src/hal/gpio.h
@@ -57,11 +57,21 @@ __attribute__((always_inline)) inline void WritePin(const GPIO_pin portPin, Leve
 }
 
 __attribute__((always_inline)) inline Level ReadPin(const GPIO_pin portPin) {
+#ifdef __AVR__
     return (Level)((portPin.port->PINx & (1 << portPin.pin)) != 0);
+#else
+    // Return the value modified by WritePin
+    return (Level)((portPin.port->PORTx & (1 << portPin.pin)) != 0);
+#endif
 }
 
 __attribute__((always_inline)) inline void TogglePin(const GPIO_pin portPin) {
+#ifdef __AVR__
+    // Optimized path for AVR, resulting in a pin toggle
     portPin.port->PINx |= (1 << portPin.pin);
+#else
+    WritePin(portPin, (Level)(ReadPin(portPin) != Level::high));
+#endif
 }
 
 __attribute__((always_inline)) inline void Init(const GPIO_pin portPin, GPIO_InitTypeDef GPIO_Init) {


### PR DESCRIPTION
The cast to Level in ReadPin is incorrect, since the expression returns either 0 or a positive value if the pin is set. The value is directly assigned to the underlying uint8_t, meaning that Level::high won't match for levels greater than 0.

Make ReadPin return the last value set by WritePin on != AVR for proper testing.

Add a slow-path to TogglePin that goes through a read-write cycle. This is useful both for testing and for platforms that don't have an efficient toggle like AVR.