### PR TITLE
pre-commit: handle cmake files in subdirectories

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
   rev: 'v0.6.0'
   hooks:
     - id: cmake-format  # cmake formatter
-      files: ^(CMakeLists.*|.*\.cmake|.*\.cmake.in)$
+      files: (^|/)(CMakeLists.*|.*\.cmake|.*\.cmake.in)$
 - repo: https://github.com/pre-commit/mirrors-yapf
   rev: 'v0.27.0'
   hooks:


### PR DESCRIPTION
Apparently "files:" receives the full path and not just the basename, so update the regex accordingly.