### PR TITLE
Allow units to be scaled by an unitless quantity

### DIFF
--- a/src/modules/axisunit.h
+++ b/src/modules/axisunit.h
@@ -73,12 +73,21 @@ struct AxisUnit {
     typedef T type_t;
     typedef AxisUnit<T, A, U> self_t;
 
-    constexpr self_t operator+(const self_t r) { return { v + r.v }; }
-    constexpr self_t operator-(const self_t r) { return { v - r.v }; }
-    constexpr self_t operator-() { return { -v }; }
-    constexpr self_t operator*(const self_t r) { return { v * r.v }; }
-    constexpr self_t operator/(const self_t r) { return { v / r.v }; }
+    // same-type operations
+    constexpr self_t operator+(const self_t r) const { return { v + r.v }; }
+    constexpr self_t operator-(const self_t r) const { return { v - r.v }; }
+    constexpr self_t operator-() const { return { -v }; }
+    constexpr self_t operator*(const self_t r) const { return { v * r.v }; }
+    constexpr self_t operator/(const self_t r) const { return { v / r.v }; }
+
+    // allow an unitless multiplier to scale the quantity: AU * f => AU
+    constexpr self_t operator*(const long double f) const { return { (T)(v * f) }; }
+    constexpr self_t operator/(const long double f) const { return { (T)(v / f) }; }
 };
+
+// complementary f * AU => AU * f
+template <typename T, Axis A, config::UnitType U>
+constexpr AxisUnit<T, A, U> operator*(const long double f, const AxisUnit<T, A, U> u) { return u * f; }
 
 /// Axis type conversion table for template expansion
 struct AxisScale {

--- a/src/unit.h
+++ b/src/unit.h
@@ -47,12 +47,21 @@ struct Unit {
     typedef T type_t;
     typedef Unit<T, B, U> self_t;
 
-    constexpr self_t operator+(const self_t r) { return { v + r.v }; }
-    constexpr self_t operator-(const self_t r) { return { v - r.v }; }
-    constexpr self_t operator-() { return { -v }; }
-    constexpr self_t operator*(const self_t r) { return { v * r.v }; }
-    constexpr self_t operator/(const self_t r) { return { v / r.v }; }
+    // same-type operations
+    constexpr self_t operator+(const self_t r) const { return { v + r.v }; }
+    constexpr self_t operator-(const self_t r) const { return { v - r.v }; }
+    constexpr self_t operator-() const { return { -v }; }
+    constexpr self_t operator*(const self_t r) const { return { v * r.v }; }
+    constexpr self_t operator/(const self_t r) const { return { v / r.v }; }
+
+    // allow an unitless multiplier to scale the quantity: U * f => U
+    constexpr self_t operator*(const long double f) const { return { (T)(v * f) }; }
+    constexpr self_t operator/(const long double f) const { return { (T)(v / f) }; }
 };
+
+// complementary f * U => U * f
+template <typename T, UnitBase B, UnitType U>
+constexpr Unit<T, B, U> operator*(const long double f, const Unit<T, B, U> u) { return u * f; }
 
 // Millimiters
 typedef Unit<long double, Millimeter, Lenght> U_mm;


### PR DESCRIPTION
This allows Unit<> and AxisUnit<> to be scaled with a fraction as
expected, promoting the scaler to the same unit:

    0.2_mm * 10 => 2_mm (mm*f => mm)

Multiplication type is commutative:

    10 * 0.2_mm => 2_mm (f*mm => mm)

Division isn't:

    0.2_mm / 10 => 0.02_mm (mm*1/f => mm)
    10 / 0.2_mm => error (illegal type conversion)

Do we want specific unit tests for type conversions?