### PR TITLE
Make cmake show verbose errors on failure

### DIFF
--- a/utils/holly/Jenkinsfile
+++ b/utils/holly/Jenkinsfile
@@ -93,6 +93,7 @@ pipeline {
                 sh """
                 python3 utils/bootstrap.py
                 export PATH=\$PWD/.dependencies/cmake-3.15.5/bin:\$PWD/.dependencies/ninja-1.9.0:\$PATH
+                export CTEST_OUTPUT_ON_FAILURE=1
                 mkdir -p build-test
                 LD_LIBRARY_PATH=/usr/local/lib32 \$PWD/.dependencies/cmake-3.15.5/bin/ctest --build-and-test . build-test \
                     -DCMAKE_MAKE_PROGRAM=\$PWD/.dependencies/ninja-1.9.0/ninja \


### PR DESCRIPTION
When a test fails, show the entire output of that test so that we can see if there's an issue with the build environment.