### PR TITLE
Implement an initial Motion ISR for AVR

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
 #include "modules/selector.h"
 #include "modules/user_input.h"
 #include "modules/timebase.h"
+#include "modules/motion.h"
 
 #include "logic/command_base.h"
 #include "logic/cut_filament.h"
@@ -126,7 +127,7 @@ void setup() {
     ml::leds.SetMode(2, ml::Color::green, ml::Mode::on);
     ml::leds.Step();
 
-    // tmc::Init()
+    mm::Init();
     ml::leds.SetMode(1, ml::Color::green, ml::Mode::on);
     ml::leds.Step();
 

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(
           movable_base.cpp
           permanent_storage.cpp
           selector.cpp
+          speed_table.cpp
           timebase.cpp
           user_input.cpp
           pulse_gen.cpp

--- a/src/modules/motion.h
+++ b/src/modules/motion.h
@@ -247,8 +247,8 @@ private:
     };
 };
 
-/// ISR stepping routine
-//extern void Isr();
+/// ISR initialization
+extern void Init();
 
 extern Motion motion;
 


### PR DESCRIPTION
This is a tentative/crude implementation of an Init and ISR for the MMU
in order to check the motion API on the real hardware.

We remove the "extern void Isr", declaring it "static inline" instead.
We need to inline the ISR here in order to avoid the function call.

Include the missing speed_table data in the executable. This bumps the
code size to ~60% of the flash.

Implemement motion::Init to setup the ISR and timers, and replace the
call in main from tmc::Init to motion::Init. Motion will init each
driver every time the axis is enabled, so there should be no need for
a global module initialization (we need SPI, but this is initialized
earlier on by it's own module anyway).

The timer is currently setup without any HAL or proper TIMER1 wrapper.
This is to be improved later.

The real MMU unit seems to slow down quite a bit during acceleration.
At this point we need to inline some methods in PulseGen to avoid
overhead, however this breaks the stubs.