### PR TITLE
Use operators for min/max

### DIFF
--- a/src/cmath.h
+++ b/src/cmath.h
@@ -3,7 +3,11 @@
 #pragma once
 
 #ifndef __AVR__
-#include <cmath>
+#include <cmath> // abs
+
+#include <algorithm>
+using std::max;
+using std::min;
 #else
 
 // AVR libc doesn't support cmath


### PR DESCRIPTION
Turns out AVR doesn't have __builtin_min/max