### PR TITLE
Fix gpio::TogglePin on AVR

### DIFF
--- a/src/hal/gpio.h
+++ b/src/hal/gpio.h
@@ -70,7 +70,7 @@ __attribute__((always_inline)) inline Level ReadPin(const GPIO_pin portPin) {
 __attribute__((always_inline)) inline void TogglePin(const GPIO_pin portPin) {
 #ifdef __AVR__
     // Optimized path for AVR, resulting in a pin toggle
-    portPin.port->PINx |= (1 << portPin.pin);
+    portPin.port->PINx = (1 << portPin.pin);
 #else
     WritePin(portPin, (Level)(ReadPin(portPin) != Level::high));
 #endif


### PR DESCRIPTION
TogglePin was incorrectly using the PINx pin for toggling, causing the
current pins (in addition to the requested ones) to be toggled, causing
stepping havoc.