### PR TITLE
Silence motion::Isr() unused variable warning

### DIFF
--- a/src/modules/motion.cpp
+++ b/src/modules/motion.cpp
@@ -97,8 +97,8 @@ st_timer_t Motion::Step() {
 }
 
 static inline void Isr() {
-    st_timer_t next = motion.Step();
 #ifdef __AVR__
+    st_timer_t next = motion.Step();
     // TODO: use proper timer abstraction
     if (next)
         OCR1A = next;


### PR DESCRIPTION
Move motion.Step() directly inside the __AVR__ code, silencing an unused
variable warning.

Calling motion.Step() without getting or setting the timer is not useful
anyway.