### PR TITLE
Fix Motion::SetMode(axis, mode) and introduce SetMode(mode)

### DIFF
--- a/src/modules/motion.cpp
+++ b/src/modules/motion.cpp
@@ -27,8 +27,12 @@ void Motion::SetEnabled(Axis axis, bool enabled) {
 }
 
 void Motion::SetMode(Axis axis, MotorMode mode) {
+    axisData[axis].drv.SetMode(axisParams[axis].params, mode);
+}
+
+void Motion::SetMode(MotorMode mode) {
     for (uint8_t i = 0; i != NUM_AXIS; ++i)
-        axisData[axis].drv.SetMode(axisParams[axis].params, mode);
+        axisData[i].drv.SetMode(axisParams[i].params, mode);
 }
 
 bool Motion::StallGuard(Axis axis) {

--- a/src/modules/motion.h
+++ b/src/modules/motion.h
@@ -92,6 +92,9 @@ public:
     /// being performed by calling QueueEmpty().
     void SetMode(Axis axis, MotorMode mode);
 
+    /// Set the same mode of TMC/motors operation for all axes. @see SetMode
+    void SetMode(MotorMode mode);
+
     /// @returns true if a stall guard event occurred recently on the axis
     bool StallGuard(Axis axis);
 


### PR DESCRIPTION
Motion::SetMode(axis, mode) was incorrectly looping through all axes,
setting the same axis three times.

Fix this and introduce Motion::SetMode(mode) which actually loops
through all axes (see PR #110)