### PR TITLE
Motion: allow to abort movement on a single axis

### DIFF
--- a/src/modules/motion.cpp
+++ b/src/modules/motion.cpp
@@ -70,9 +70,13 @@ bool Motion::QueueEmpty() const {
     return true;
 }
 
+void Motion::AbortPlannedMoves(Axis axis, bool halt) {
+    axisData[axis].ctrl.AbortPlannedMoves(halt);
+}
+
 void Motion::AbortPlannedMoves(bool halt) {
     for (uint8_t i = 0; i != NUM_AXIS; ++i)
-        axisData[i].ctrl.AbortPlannedMoves(halt);
+        AbortPlannedMoves((Axis)i, halt);
 }
 
 st_timer_t Motion::Step() {

--- a/src/modules/motion.h
+++ b/src/modules/motion.h
@@ -255,7 +255,12 @@ public:
     /// @param axis axis requested
     bool Full(Axis axis) const { return axisData[axis].ctrl.Full(); }
 
-    /// stop whatever moves are being done
+    /// Stop whatever moves are being done for one axis
+    /// @param axis axis requested
+    /// @param halt When true, also abruptly stop axis movement.
+    void AbortPlannedMoves(Axis axis, bool halt = true);
+
+    /// Stop whatever moves are being done on all axes
     /// @param halt When true, also abruptly stop axis movement.
     void AbortPlannedMoves(bool halt = true);
 


### PR DESCRIPTION
This can be useful for things like faster homing in the future and comes
at no expense.