### PR TITLE
Fix unit test compatibility with mingw

### DIFF
--- a/tests/unit/modules/motion/rampgen.cpp
+++ b/tests/unit/modules/motion/rampgen.cpp
@@ -1,5 +1,11 @@
 #include <cstdio>
+#ifndef __WIN32__
 #include <sysexits.h>
+#else
+#define EX_OK 0
+#define EX_USAGE 64
+#define EX_OSERR 71
+#endif
 
 #include "motion.h"
 using namespace modules::motion;


### PR DESCRIPTION
Proposal for a workaround for people who suffer from Windows (like me). Mingw lacks sysexits.h, so we just hardcode the defines that we care about here for the code to compile successfully.