### PR TITLE
Shr16 correct signal timing

### DIFF
--- a/src/hal/avr/shr16.cpp
+++ b/src/hal/avr/shr16.cpp
@@ -33,8 +33,9 @@ void SHR16::Write(uint16_t v) {
     }
     WritePin(SHR16_CLOCK, Level::low);
     WritePin(SHR16_LATCH, Level::high);
-    _delay_us(25);
+    _delay_us(15);
     WritePin(SHR16_LATCH, Level::low);
+    _delay_us(15);
 
     shr16_v = v;
 }


### PR DESCRIPTION
Follow `Figure 6-1. Timing Diagram` from https://www.ti.com/lit/ds/symlink/sn74hc595.pdf?ts=1637644361025
I misunderstood how this IC is used correctly. I'm surprised that it worked at all. Now random pins won't flash anymore. The only thing left to be investigated is the latch timing because of that stupid capacitor on the line. I'll attach my oscilloscope to the LATCH line when I have time. I want to see the slew rate of that line and if we are within parameters with the new timing. I pushed the timing to the extreme by temporarely reverting the led caching, so that many shr16 updates happened. These changes weren't pushed (because the leds really need caching).