### PR TITLE
Enforce MMU flash space limits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,9 @@ if(CMAKE_CROSSCOMPILING)
   add_link_dependency(firmware ${LINKER_SCRIPT})
   #]]
 
+  # limit the text section to 28K (32K - 4k reserved for the bootloader)
+  target_link_options(firmware PUBLIC -Wl,--defsym=__TEXT_REGION_LENGTH__=28K)
+
   # generate firmware.bin file
   objcopy(firmware "ihex" ".hex")
 


### PR DESCRIPTION
The bootloader resides in the upper 4k region of the flash, leaving us with only 28K effectively usable.
@leptun I hope this is still correct.

 ``avr-size`` doesn't seem to have an option to check for an arbitrary limit, but the default avr linker script in gcc can be configured to do so.

With this in place, the build fails with:

```
/usr/lib/gcc/avr/5.4.0/../../../avr/bin/ld: firmware section `.text' will not fit in region `text'
/usr/lib/gcc/avr/5.4.0/../../../avr/bin/ld: region `text' overflowed by 1682 bytes
collect2: error: ld returned 1 exit status
```
