### PR TITLE
Invalidate currentSlot while homing

### DIFF
--- a/src/modules/movable_base.cpp
+++ b/src/modules/movable_base.cpp
@@ -15,8 +15,9 @@ void MovableBase::PlanHome() {
     mm::motion.StallGuardReset(axis);
 
     // plan move at least as long as the axis can go from one side to the other
-    PlanHomingMoveForward(); // mm::motion.PlanMove(axis, delta, 1000);
+    PlanHomingMoveForward();
     state = HomeForward;
+    currentSlot = -1; // important - other state machines may be waiting for a valid Slot() which is not yet correct while homing in progress
 }
 
 MovableBase::OperationResult MovableBase::InitMovement() {
@@ -66,7 +67,7 @@ void MovableBase::PerformHomeBack() {
             HomeFailed();
         } else {
             homingValid = true;
-            // state = Ready; // not yet - we have to move to our parking position after homing the axis
+            // state = Ready; // not yet - we have to move to our parking or target position after homing the axis
         }
     } else if (mm::motion.QueueEmpty(axis)) {
         HomeFailed();

--- a/src/modules/movable_base.h
+++ b/src/modules/movable_base.h
@@ -38,8 +38,9 @@ public:
     /// virtual ~MovableBase(); intentionally disabled, see description in logic::CommandBase
 
     /// @returns currently active slot
-    /// this state is updated only when a planned move is successfully finished, so it is safe for higher-level
+    /// This state is updated only when a planned move is successfully finished, so it is safe for higher-level
     /// state machines to use this call as a waiting condition for the desired state of the derive class (idler/selector)
+    /// While homing, Slot() returns 0xff as the current slot index is invalid.
     inline uint8_t Slot() const { return currentSlot; }
 
     /// @returns internal state of the state machine

--- a/tests/unit/logic/helpers/helpers.ipp
+++ b/tests/unit/logic/helpers/helpers.ipp
@@ -28,6 +28,15 @@ bool VerifyEnvironmentState(mg::FilamentLoadState fls, uint8_t idlerSlotIndex, u
         return false;
         }
     }
+    if( mi::idler.State() == mi::Idler::HomeForward || mi::idler.State() == mi::Idler::HomeBack ){
+        CHECKED_ELSE(mi::idler.Slot() == 0xff){
+        return false;
+        }
+        CHECKED_ELSE(mi::idler.HomingValid() == false){
+        return false;
+        }
+    }
+
     if( selectorSlotIndex < config::toolCount ){ // abusing invalid index to skip checking of slot and position
         CHECKED_ELSE(mm::axes[mm::Selector].pos == ms::Selector::SlotPosition(selectorSlotIndex).v) {
         return false;
@@ -36,6 +45,15 @@ bool VerifyEnvironmentState(mg::FilamentLoadState fls, uint8_t idlerSlotIndex, u
         return false;
         }
     }
+    if( ms::selector.State() == ms::Selector::HomeForward || ms::selector.State() == ms::Selector::HomeBack ){
+        CHECKED_ELSE(ms::selector.Slot() == 0xff){
+        return false;
+        }
+        CHECKED_ELSE(ms::selector.HomingValid() == false){
+        return false;
+        }
+    }
+
     CHECKED_ELSE(mf::finda.Pressed() == findaPressed) {
     return false;
     }

--- a/tests/unit/logic/unload_filament/test_unload_filament.cpp
+++ b/tests/unit/logic/unload_filament/test_unload_filament.cpp
@@ -76,6 +76,7 @@ void RegularUnloadFromSlot04(uint8_t slot, logic::UnloadFilament &uf, uint8_t en
     REQUIRE(WhileTopState(uf, ProgressCode::DisengagingIdler, idlerEngageDisengageMaxSteps));
 
     if (selectorShallHomeAtEnd) {
+        REQUIRE(ms::selector.Slot() == 0xff);
         SimulateSelectorHoming(uf);
     }
 


### PR DESCRIPTION
makes calls to Slot() consistent and reliable