### PR TITLE
Guard critical sections in modules::motion

### DIFF
--- a/src/modules/motion.h
+++ b/src/modules/motion.h
@@ -179,7 +179,7 @@ public:
     /// probably be used instead.
     /// @param axis axis affected
     /// @returns the current position of the axis
-    pos_t CurPosition(Axis axis) const { return axisData[axis].ctrl.CurPosition(); }
+    pos_t CurPosition(Axis axis) const;
 
     /// Fetch the current axis position, but in AxisUnit. This function is expensive!
     /// The Axis needs to be supplied as the first template argument: CurPosition<axis>().

--- a/tests/unit/logic/stubs/stub_motion.cpp
+++ b/tests/unit/logic/stubs/stub_motion.cpp
@@ -46,6 +46,10 @@ pos_t Motion::Position(Axis axis) const {
     return axes[axis].pos;
 }
 
+pos_t Motion::CurPosition(Axis axis) const {
+    return axes[axis].pos;
+}
+
 void Motion::SetPosition(Axis axis, pos_t x) {
     axes[axis].pos = x;
     axisData[axis].ctrl.SetPosition(axes[axis].pos);


### PR DESCRIPTION
While motion queuing is safe, code that relies on the current block
needs to run with the isr disabled.

Protect AbortPlannedMoves and CurPosition from isr' interference by
using a RAII guard.