### PR TITLE
Try to recover FINDA pressed + no EEPROM record at start

### DIFF
--- a/src/logic/error_codes.h
+++ b/src/logic/error_codes.h
@@ -39,6 +39,8 @@ enum class ErrorCode : uint_fast16_t {
     HOMING_IDLER_FAILED = HOMING_FAILED | TMC_IDLER_BIT, ///< E33031 the Idler was unable to home properly - that means something is blocking its movement
     STALLED_PULLEY = HOMING_FAILED | TMC_PULLEY_BIT, ///< E32839 for the Pulley "homing" means just stallguard detected during Pulley's operation (Pulley doesn't home)
 
+    FINDA_VS_EEPROM_DISREPANCY = 0x8008, ///< E32776 FINDA is pressed but we have no such record in EEPROM - this can only happen at the start of the MMU and can be resolved by issuing an Unload command
+
     QUEUE_FULL = 0x802b, ///< E32811 internal logic error - attempt to move with a full queue
 
     VERSION_MISMATCH = 0x802c, ///< E32812 internal error of the printer - incompatible version of the MMU FW

--- a/src/logic/no_command.h
+++ b/src/logic/no_command.h
@@ -16,6 +16,11 @@ public:
 
     /// @returns true if the state machine finished its job, false otherwise
     bool StepInner() override { return true; }
+
+    /// Used to report initialization errors (which can be reported if the UART started up).
+    /// Intentionally only available in the "noCommand" operation
+    /// which is only active when the MMU starts and before it gets any other command from the printer.
+    inline void SetInitError(ErrorCode ec) { error = ec; }
 };
 
 /// The one and only instance of NoCommand state machine in the FW

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,8 @@
 
 #include "application.h"
 
+#include "logic/no_command.h"
+
 /// One-time setup of HW and SW components
 /// Called before entering the loop() function
 /// Green LEDs signalize the progress of initialization. If anything goes wrong we shall turn on a red LED
@@ -90,6 +92,7 @@ void setup() {
         // For this we speculatively set the active slot to 2 (in the middle ;) )
         // Ideally this should be signalled as an error state and displayed on the printer and recovered properly.
         mg::globals.SetFilamentLoaded(2, mg::InFSensor);
+        logic::noCommand.SetInitError(ErrorCode::FINDA_VS_EEPROM_DISREPANCY);
     }
 
     /// Turn off all leds


### PR DESCRIPTION
Try to recover a startup scenario with FINDA pressed while no EEPROM filament loaded record is present.

MMU-140