### PR TITLE
:construction: Slower Pulley acceleration

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -112,7 +112,7 @@ static constexpr AxisConfig pulley = {
 static constexpr PulleyLimits pulleyLimits = {
     .lenght = 1000.0_mm, // TODO
     .jerk = 4.0_mm_s,
-    .accel = 800.0_mm_s2,
+    .accel = 200.0_mm_s2,
 };
 
 static constexpr U_mm_s pulleyUnloadFeedrate = 120._mm_s;


### PR DESCRIPTION
Make acceleration of the Pulley slower in all cases. It may help pulling the filament out of the extruder in some rare cases
as requested in MMU-113.