### PR TITLE
Make idler less sensitive SGT=5 -> SGT=7

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -179,7 +179,7 @@ static constexpr AxisConfig idler = {
     .iHold = 23, /// 398mA
     .stealth = false,
     .stepsPerUnit = (200 * 16 / 360.),
-    .sg_thrs = 5,
+    .sg_thrs = 7,
 };
 
 /// Idler motion limits


### PR DESCRIPTION
This should eliminate the issue where the idler detects the individual filaments as the home position

MMU-112