### PR TITLE
motion: Fix motion::triple_move step count limit

### DIFF
--- a/tests/unit/modules/motion/test_motion.cpp
+++ b/tests/unit/modules/motion/test_motion.cpp
@@ -216,7 +216,7 @@ TEST_CASE("motion::triple_move", "[motion]") {
     motion.PlanMoveTo(Pulley, p, 1);
 
     // perform the move with a maximum step limit
-    REQUIRE(stepUntilDone(std::max({ i, s, p }) + 1) != -1);
+    REQUIRE(stepUntilDone(i + s + p) != -1);
 
     // check queue status
     REQUIRE(motion.QueueEmpty());


### PR DESCRIPTION
Do not assume any step can be merged while moving three axes at the same
time.

Use the worst case scenario involving indepedent parameters for each
axis.