### PR TITLE
Distinguish fast and slow feed stage

### DIFF
--- a/src/logic/error_codes.h
+++ b/src/logic/error_codes.h
@@ -41,6 +41,11 @@ enum class ErrorCode : uint_fast16_t {
 
     FINDA_VS_EEPROM_DISREPANCY = 0x8008, ///< E32776 FINDA is pressed but we have no such record in EEPROM - this can only happen at the start of the MMU and can be resolved by issuing an Unload command
 
+    FSENSOR_TOO_EARLY = 0x8009, ///< E32777 FSensor triggered while doing FastFeedToBondtech - that means either:
+    ///< - the PTFE is too short
+    ///< - a piece of filament was left inside - pushed in front of the loaded filament causing the fsensor trigger too early
+    ///< - fsensor is faulty producing bogus triggers
+
     QUEUE_FULL = 0x802b, ///< E32811 internal logic error - attempt to move with a full queue
 
     VERSION_MISMATCH = 0x802c, ///< E32812 internal error of the printer - incompatible version of the MMU FW

--- a/src/logic/feed_to_bondtech.h
+++ b/src/logic/feed_to_bondtech.h
@@ -14,11 +14,14 @@ struct FeedToBondtech {
     /// internal states of the state machine
     enum {
         EngagingIdler,
+        PushingFilamentFast,
         PushingFilamentToFSensor,
         PushingFilamentIntoNozzle,
         DisengagingIdler,
         OK,
-        Failed
+        Failed,
+        FSensorTooEarly,
+        //        PulleyStalled
     };
 
     inline FeedToBondtech()

--- a/src/logic/progress_codes.h
+++ b/src/logic/progress_codes.h
@@ -39,5 +39,7 @@ enum class ProgressCode : uint_fast8_t {
     Homing, // P26
     MovingSelector, // P27
 
+    FeedingToFSensor, // P28
+
     Empty = 0xff // dummy empty state
 };


### PR DESCRIPTION
Originally, only FeedingToBondtech was reported to the printer.
With PR#173 we have this operation separated into a fast and a slow stage (for MK3S with the chimney).
It looks like the printer could benefit from knowing if the MMU is still pushing fast
or when it entered the slow stage (to prevent ramming hard the Bondtech gears)

Along with this new state being reported, we also introduce a new ErrorCode::FSENSOR_TOO_EARLY
which basically means that the fsensor triggered in the fast feeding stage.

MMU-150