### PR TITLE
:construction:  Introduce NO_FINDA_BUT_EEPROM_HAS_FILAMENT error

### DIFF
--- a/src/logic/error_codes.h
+++ b/src/logic/error_codes.h
@@ -39,7 +39,8 @@ enum class ErrorCode : uint_fast16_t {
     HOMING_IDLER_FAILED = HOMING_FAILED | TMC_IDLER_BIT, ///< E33031 the Idler was unable to home properly - that means something is blocking its movement
     STALLED_PULLEY = HOMING_FAILED | TMC_PULLEY_BIT, ///< E32839 for the Pulley "homing" means just stallguard detected during Pulley's operation (Pulley doesn't home)
 
-    FINDA_VS_EEPROM_DISREPANCY = 0x8008, ///< E32776 FINDA is pressed but we have no such record in EEPROM - this can only happen at the start of the MMU and can be resolved by issuing an Unload command
+    FINDA_PRESSED_BUT_NO_EEPROM_RECORD = 0x8008, ///< E32776 FINDA is pressed but we have no such record in EEPROM - this can only happen at the start of the MMU and can be resolved by issuing an Unload command
+    NO_FINDA_BUT_EEPROM_HAS_FILAMENT = 0x800b, ///< E32779 opposite scenario - FINDA not pressed but there is a filament record in the EEPROM. Resolve: Unload, Done (clears the EEPROM)
 
     FSENSOR_TOO_EARLY = 0x8009, ///< E32777 FSensor triggered while doing FastFeedToBondtech - that means either:
     ///< - the PTFE is too short

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,7 +92,15 @@ void setup() {
         // For this we speculatively set the active slot to 2 (in the middle ;) )
         // Ideally this should be signalled as an error state and displayed on the printer and recovered properly.
         mg::globals.SetFilamentLoaded(2, mg::InFSensor);
-        logic::noCommand.SetInitError(ErrorCode::FINDA_VS_EEPROM_DISREPANCY);
+        logic::noCommand.SetInitError(ErrorCode::FINDA_PRESSED_BUT_NO_EEPROM_RECORD);
+    }
+
+    if (!mf::finda.Pressed() && mg::globals.FilamentLoaded() >= mg::InSelector) {
+        // Opposite situation - not so dangerous, but definitely confusing to users.
+        // FINDA is not pressed but we have a record in the EEPROM.
+        // The user must tell us if there is filament (FINDA doesn't work correctly)
+        // or not (filament pulled out while the MMU was off - which is the usual case)
+        logic::noCommand.SetInitError(ErrorCode::NO_FINDA_BUT_EEPROM_HAS_FILAMENT);
     }
 
     /// Turn off all leds


### PR DESCRIPTION
This PR introduces NO_FINDA_BUT_EEPROM_HAS_FILAMENT
This error will get triggered upod start of the FW when FINDA is not pressed but there is a record of some filament present in the EEPROM.

This PR is intentionally marked as :construction: due to Content team's decision, that we shall clear the EEPROM flag automatically in such a situation and not report this error at all (which requires a working FINDA)