### PR TITLE
Increment MMU error count with every new error ocurred

### DIFF
--- a/src/logic/command_base.cpp
+++ b/src/logic/command_base.cpp
@@ -189,6 +189,7 @@ bool CommandBase::CheckToolIndex(uint8_t index) {
 void CommandBase::ErrDisengagingIdler() {
     if (!mi::idler.Engaged()) {
         state = ProgressCode::ERRWaitingForUser;
+        mg::globals.IncDriveErrors();
         mpu::pulley.Disable();
         mui::userInput.Clear(); // remove all buffered events if any just before we wait for some input
     }


### PR DESCRIPTION
All the infrastructure has already been there but no IncDriveErrors() was ever called.

MMU-166