### PR TITLE
Introduce Idler::PartiallyDisengage

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -204,6 +204,16 @@ static constexpr U_deg idlerSlotPositions[toolCount + 1] = {
     IdlerOffsetFromHome ///18.0_deg Fully disengaged all slots
 };
 
+/// Intermediate positions for Idler's slots: 0-4 are the real ones, the 5th index is the idle position
+static constexpr U_deg idlerIntermediateSlotPositions[toolCount + 1] = {
+    IdlerOffsetFromHome + 4.5F * IdlerSlotDistance,
+    IdlerOffsetFromHome + 3.5F * IdlerSlotDistance,
+    IdlerOffsetFromHome + 2.5F * IdlerSlotDistance,
+    IdlerOffsetFromHome + 1.5F * IdlerSlotDistance,
+    IdlerOffsetFromHome + 0.5F * IdlerSlotDistance,
+    IdlerOffsetFromHome ///18.0_deg Fully disengaged all slots
+};
+
 static constexpr U_deg idlerParkPositionDelta = -IdlerSlotDistance + 5.0_deg / 2; ///@TODO verify
 
 static constexpr U_deg_s idlerFeedrate = 300._deg_s;

--- a/src/logic/command_base.cpp
+++ b/src/logic/command_base.cpp
@@ -187,7 +187,7 @@ bool CommandBase::CheckToolIndex(uint8_t index) {
 }
 
 void CommandBase::ErrDisengagingIdler() {
-    if (!mi::idler.Engaged()) {
+    if (mi::idler.Disengaged()) {
         state = ProgressCode::ERRWaitingForUser;
         error = deferredErrorCode;
         deferredErrorCode = ErrorCode::OK; // and clear the deferredEC just for safety

--- a/src/logic/eject_filament.cpp
+++ b/src/logic/eject_filament.cpp
@@ -66,7 +66,7 @@ bool EjectFilament::StepInner() {
         }
         break;
     case ProgressCode::DisengagingIdler:
-        if (!mi::idler.Engaged()) { // idler disengaged
+        if (mi::idler.Disengaged()) { // idler disengaged
             mpu::pulley.Disable();
             mg::globals.SetFilamentLoaded(mg::globals.ActiveSlot(), mg::FilamentLoadState::NotLoaded);
             FinishedOK();

--- a/src/logic/feed_to_bondtech.h
+++ b/src/logic/feed_to_bondtech.h
@@ -17,6 +17,7 @@ struct FeedToBondtech {
         PushingFilamentFast,
         PushingFilamentToFSensor,
         PushingFilamentIntoNozzle,
+        PartiallyDisengagingIdler,
         DisengagingIdler,
         OK,
         Failed,

--- a/src/logic/load_filament.cpp
+++ b/src/logic/load_filament.cpp
@@ -100,8 +100,8 @@ bool LoadFilament::StepInner() {
     case ProgressCode::DisengagingIdler:
         // beware - this state is being reused for error recovery
         // and if the selector decided to re-home, we have to wait for it as well
-        // therefore: 'if (!mi::idler.Engaged())' : alone is not enough
-        if (!mi::idler.Engaged() && ms::selector.Slot() == mg::globals.ActiveSlot()) {
+        // therefore: 'if (mi::idler.Disengaged())' : alone is not enough
+        if (mi::idler.Disengaged() && ms::selector.Slot() == mg::globals.ActiveSlot()) {
             LoadFinishedCorrectly();
         }
         break;

--- a/src/logic/unload_filament.cpp
+++ b/src/logic/unload_filament.cpp
@@ -79,7 +79,7 @@ bool UnloadFilament::StepInner() {
         }
         return false;
     case ProgressCode::DisengagingIdler:
-        if (!mi::idler.Engaged() && ms::selector.State() == ms::Selector::Ready) {
+        if (mi::idler.Disengaged() && ms::selector.State() == ms::Selector::Ready) {
             UnloadFinishedCorrectly();
         }
         return false;


### PR DESCRIPTION
This is to solve a potential problem while feeding to printer's drive gears - while disengaging the Idler, the Pulley was still rotating to avoid grinding the filament (printer is pulling it).

Other filaments could have moved a bit when the Idler's bearings ran over them while the Pulley was still rotating slowly -> the filament could have been moved into the Selector's path causing trouble (especially when not used in the print).

Therefore, the Idler disengages partially now - moves into an intermediate position between the slots.
Then, the Pulley is completely stopped and after that the Idler does a full disengage like before.

MMU-174