### PR TITLE
Implement Idler moves via registers

### DIFF
--- a/src/registers.cpp
+++ b/src/registers.cpp
@@ -221,7 +221,7 @@ static const RegisterRec registers[] /*PROGMEM*/ = {
     // 0x1c Set/Get Idler slot RW
     RegisterRec(
         []() -> uint16_t { return mi::idler.Slot(); },
-        // [](uint16_t d) { mi::idler.MoveToSlot(d); }, // @@TODO can be theoretically done as well
+        [](uint16_t d) { d >= config::toolCount ? mi::idler.Disengage() : mi::idler.Engage(d); },
         1),
 
 };


### PR DESCRIPTION
The only downside of the current implementation is the necessity to disengage the idler first before some other slot can be chosen. Good enough for the early tests, we can then decide if we need better implementation.