### PR TITLE
Don't detach USB before entering bootloader

### DIFF
--- a/src/hal/avr/cpu.cpp
+++ b/src/hal/avr/cpu.cpp
@@ -27,7 +27,6 @@ void Reset() {
 void Step() {
     if (resetPending) {
         hal::usart::usart1.puts("resetPending\n");
-        USB_Detach();
         for (;;)
             ; //endless loop while waiting for the watchdog to reset
     }


### PR DESCRIPTION
Fixes this error when flashing via PrusaSlicer:

![image](https://user-images.githubusercontent.com/8218499/194620729-8e8879fa-f180-4a17-a5bf-b756cd9d30e6.png)
