### PR TITLE
Fix: `python3` is invalid on Windows platform

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,8 +18,9 @@ if (GCOV_ENABLE)
 	# pass, .ctest-finished is created and we can check for its existance after generating the report to determine if the overall
 	# build result is a pass or fail. 
 	add_custom_target(test_run_all
-		COMMAND cd ${PROJECT_BINARY_DIR} 
-		COMMAND ${CMAKE_COMMAND} -E env CTEST_OUTPUT_ON_FAILURE=1 ${CMAKE_CTEST_COMMAND} --timeout 20 --repeat <after-timeout>:<3> && ${CMAKE_COMMAND} -E touch .ctest-finished || exit 0
+		COMMAND ${CMAKE_COMMAND} -E env CTEST_OUTPUT_ON_FAILURE=1 ${CMAKE_CTEST_COMMAND} --timeout 30
+		COMMAND ${CMAKE_COMMAND} -E touch .ctest-finished || exit 0
+		WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
 		DEPENDS tests_clean tests
 	)
 


### PR DESCRIPTION
Use the Python executable found when configuring the project.