### PR TITLE
build: Set -mrelax to remove trampolines while linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ if(CMAKE_CROSSCOMPILING)
   set(CMAKE_C_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
 
   # mcu related settings
-  set(MCU_FLAGS -mmcu=atmega32u4 -DF_CPU=16000000L)
+  set(MCU_FLAGS -mmcu=atmega32u4 -DF_CPU=16000000L -mrelax)
   add_compile_options(${MCU_FLAGS})
   add_link_options(${MCU_FLAGS})
 


### PR DESCRIPTION
Avr GCC automatically marks all indirect calls for trampoline generation irregardless of the target.

This can be avoided by forcing -mshort-calls or using -mrelax that removes the trampoline at link time (after the call location has been proven to be reachable).

This saves 510 bytes on the current build (the trampolines section is now empty as expected).