### PR TITLE
user input test: Register enum with Catch

### DIFF
--- a/tests/unit/modules/user_input/test_user_input.cpp
+++ b/tests/unit/modules/user_input/test_user_input.cpp
@@ -5,6 +5,13 @@
 #include "../hal/adc.h"
 #include "user_input.h"
 
+CATCH_REGISTER_ENUM(mui::Event,
+    mui::Event::NoEvent,
+    mui::Event::Left,
+    mui::Event::Middle,
+    mui::Event::Right,
+    mui::Event::FromPrinter)
+
 void PressButtonAndDebounce(uint8_t btnIndex) {
     hal::adc::SetADC(config::buttonsADCIndex, config::buttonADCLimits[btnIndex][0] + 1);
     while (!mb::buttons.ButtonPressed(btnIndex)) {


### PR DESCRIPTION
Now when `REQUIRE ( a == b )` fails we see the values of `a` and `b`.



**BEFORE**

![image](https://user-images.githubusercontent.com/8218499/196046828-f0f65a1d-7b19-4049-99c8-10884a0129f3.png)


**AFTER:**

![image](https://user-images.githubusercontent.com/8218499/196045171-80bb974f-fddc-41d4-a745-c988f07b8a8b.png)


