### PR TITLE
hwSanity: Disable the steppers after test

### DIFF
--- a/src/logic/hw_sanity.cpp
+++ b/src/logic/hw_sanity.cpp
@@ -131,6 +131,7 @@ bool HWSanity::StepInner() {
             test_step++;
         } else {
             // This pass is complete. Move on to the next motor or cleanup.
+            driver.SetEnabled(params, false);
             driver.SetBridgeOutput(params, true);
             test_step = 0;
             state = next_state;


### PR DESCRIPTION
This makes it so the uninitialized steppers don't stay enabled on startup if no move is executed (eg, if homing is blocked by the filament at finda)

flash: -44
RAM: 0