### PR TITLE
Run unit tests in parallel when possible

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,7 +20,9 @@ if(GCOV_ENABLE)
   include(ProcessorCount)
   ProcessorCount(N)
   if(N EQUAL 0)
-    message(WARNING "CTest: There was an issue reading the core count, tests won't be run in parallel")
+    message(
+      WARNING "CTest: There was an issue reading the core count, tests won't be run in parallel"
+      )
   else()
     message(STATUS "CTest: Detected ${N} CPU threads")
     set(ctest_test_args -j${N} ${ctest_test_args})


### PR DESCRIPTION
`ReadResponse` unit test usually takes at least 30 seconds to run on my
computer, so having the unit tests run on more than one thread makes a
big difference. Currently this saves around 25-35 seconds on my end.