### PR TITLE
Empty the entire block_index queue when planned moves are aborted

### DIFF
--- a/src/modules/pulse_gen.cpp
+++ b/src/modules/pulse_gen.cpp
@@ -160,9 +160,11 @@ void PulseGen::AbortPlannedMoves(bool halt) {
     if (current_block) {
         last_rate = acc_step_rate;
         current_block = nullptr;
-        while (!block_index.empty()) // drop all remaining blocks
-            block_index.pop();
     }
+
+    // drop all remaining blocks
+    while (!block_index.empty())
+        block_index.pop();
 
     // truncate the last rate if halting
     if (halt)


### PR DESCRIPTION
The fixes an issue where the idler can eject all filaments outside their slot by around few cm or more.

Steps to reproduce issue https://dev.prusa3d.com/browse/PFW-1370:
1. Turn on printer
2. Preheat extruder
3. Trigger the Fsensor to 1 (constantly) -- I do this by pressing the lever on the plastic housing
4. Select "Load to Nozzle" from LCD and select any slot
5. Wait for failure to appear
6. Issue appears during one of the retry attempts before showing Fsensor too early error.

When the error is first reported, `AbortPlannedMoves` is called for all axis. Then when the retry attempts start, there are still queued moves in the block buffer causing both pulley and idler to move at the same time.

Change in memory:
Flash: 0 bytes
SRAM: 0 bytes