### PR TITLE
circular_buffer: implement `reset()`

### DIFF
--- a/src/hal/circular_buffer.h
+++ b/src/hal/circular_buffer.h
@@ -31,6 +31,11 @@ public:
         return ((index_t)(head - tail) % (size * 2)) == size;
     }
 
+    /// Reset the indexes to empty
+    inline void reset() {
+        head = tail;
+    }
+
     /// Advance the head index of the buffer.
     /// No checks are performed. full() needs to be queried beforehand.
     inline void push() {
@@ -99,6 +104,11 @@ public:
 
     bool full() const {
         return index.full();
+    }
+
+    /// Reset the circular buffer to empty
+    inline void reset() {
+        index.reset();
     }
 
     /// Insert an element into the buffer.

--- a/src/modules/pulse_gen.cpp
+++ b/src/modules/pulse_gen.cpp
@@ -163,8 +163,7 @@ void PulseGen::AbortPlannedMoves(bool halt) {
     }
 
     // drop all remaining blocks
-    while (!block_index.empty())
-        block_index.pop();
+    block_index.reset();
 
     // truncate the last rate if halting
     if (halt)

--- a/src/modules/user_input.cpp
+++ b/src/modules/user_input.cpp
@@ -55,10 +55,7 @@ Event UserInput::ConsumeEventForPrinter() {
 }
 
 void UserInput::Clear() {
-    while (!eventQueue.empty()) {
-        Event x;
-        eventQueue.pop(x);
-    }
+    eventQueue.reset();
 }
 
 } // namespace user_input

--- a/tests/unit/hal/circular_buffer/test_circular_buffer.cpp
+++ b/tests/unit/hal/circular_buffer/test_circular_buffer.cpp
@@ -63,6 +63,31 @@ TEST_CASE("circular_buffer::fill", "[circular_buffer]") {
     REQUIRE(cb.count() == 0);
 }
 
+TEST_CASE("circular_buffer::reset", "[circular_buffer]") {
+
+    static constexpr auto size = 2;
+    using CB = CircularBuffer<uint8_t, uint8_t, size>;
+
+    // start with an empty buffer
+    CB cb;
+    REQUIRE(cb.empty());
+
+    // push four elements
+    REQUIRE(cb.push(1));
+    REQUIRE(cb.push(2));
+
+    // Check there are elements in the buffer
+    REQUIRE(cb.full());
+    REQUIRE(!cb.empty());
+
+    // Reset the buffer
+    cb.reset();
+
+    // Buffer should be empty now
+    REQUIRE(cb.empty());
+    REQUIRE(cb.count() == 0);
+}
+
 TEST_CASE("circular_buffer::wrap_around", "[circular_buffer]") {
 
     static constexpr auto size = 4;


### PR DESCRIPTION
`reset()` discards any data in the buffer (`head == tail`). This is more efficient than using `pop()` to remove one element at a time.

Borrowed from https://github.com/prusa3d/Prusa-Firmware-MMU-Private/pull/209

Change in memory:
Flash: -116 bytes
SRAM: 0 bytes