### PR TITLE
Make sure ToolChange moves Selector to desired slot

### DIFF
--- a/src/logic/tool_change.cpp
+++ b/src/logic/tool_change.cpp
@@ -43,10 +43,10 @@ bool ToolChange::Reset(uint8_t param) {
         unl.Reset(mg::globals.ActiveSlot());
     } else {
         unloadAlreadyFinished = true;
+        mg::globals.SetFilamentLoaded(plannedSlot, mg::FilamentLoadState::InSelector); // activate the correct slot, feed uses that
         if (feed.Reset(true, false)) {
             state = ProgressCode::FeedingToFinda;
             error = ErrorCode::RUNNING;
-            //        mg::globals.SetFilamentLoaded(plannedSlot, mg::FilamentLoadState::InSelector); // this is set in feed @@TODO
             dbg_logic_P(PSTR("Filament is not loaded --> load"));
         } else {
             // selector refused to move - FINDA problem suspected

--- a/src/modules/movable_base.h
+++ b/src/modules/movable_base.h
@@ -68,7 +68,9 @@ public:
 
     inline config::Axis Axis() const { return axis; }
 
+#ifndef UNITTEST
 protected:
+#endif
     /// internal state of the automaton
     uint8_t state;
 


### PR DESCRIPTION
and verify correct behaviour in unit tests - especially when Selector's start position is at a different slot.

MMU-196