### PR TITLE
Distinguish among different error states when recovering ToolChange

### DIFF
--- a/src/logic/tool_change.h
+++ b/src/logic/tool_change.h
@@ -38,10 +38,6 @@ private:
     FeedToFinda feed;
     FeedToBondtech james; // bond ;)
     uint8_t plannedSlot;
-
-    /// true if the unload phase was either not necessary or finished correctly.
-    /// Part of the flickering FINDA issue
-    bool unloadAlreadyFinished;
 };
 
 /// The one and only instance of ToolChange state machine in the FW

--- a/tests/unit/logic/helpers/helpers.ipp
+++ b/tests/unit/logic/helpers/helpers.ipp
@@ -64,17 +64,21 @@ bool VerifyEnvironmentState(mg::FilamentLoadState fls, uint8_t idlerSlotIndex, u
     for(uint8_t ledIndex = 0; ledIndex < config::toolCount; ++ledIndex){
         if( ledIndex != selectorSlotIndex ){
             // the other LEDs should be off
-            CHECKED_ELSE(ml::leds.Mode(ledIndex, ml::red) == ml::off) {
+            auto red = ml::leds.Mode(ledIndex, ml::red);
+            CHECKED_ELSE(red == ml::off) {
             return false;
             }
-            CHECKED_ELSE(ml::leds.Mode(ledIndex, ml::green) == ml::off) {
+            auto green = ml::leds.Mode(ledIndex, ml::green);
+            CHECKED_ELSE(green == ml::off) {
             return false;
             }
         } else {
-            CHECKED_ELSE(ml::leds.Mode(selectorSlotIndex, ml::red) == redLEDMode) {
+            auto red = ml::leds.Mode(selectorSlotIndex, ml::red);
+            CHECKED_ELSE(red == redLEDMode) {
             return false;
             }
-            CHECKED_ELSE(ml::leds.Mode(selectorSlotIndex, ml::green) == greenLEDMode) {
+            auto green = ml::leds.Mode(selectorSlotIndex, ml::green);
+            CHECKED_ELSE(green == greenLEDMode) {
             return false;
             }
         }

--- a/tests/unit/logic/stubs/main_loop_stub.cpp
+++ b/tests/unit/logic/stubs/main_loop_stub.cpp
@@ -76,6 +76,7 @@ void ForceReinitAllAutomata() {
     mm::ReinitMotion();
 
     // let's assume we have the filament NOT loaded and active slot 0
+    mg::globals.Init();
     mg::globals.SetFilamentLoaded(mg::globals.ActiveSlot(), mg::FilamentLoadState::AtPulley);
 }
 


### PR DESCRIPTION
Some errors need specific recovery, it seems it is no longer possible to "just" retry.

Depends on MMU-196 (PR #242)

MMU-197