### PR TITLE
optimisation: compiler should not inline `SetFilamentLoaded()`

### DIFF
--- a/src/modules/globals.h
+++ b/src/modules/globals.h
@@ -44,7 +44,7 @@ public:
     /// Sets the filament loaded flag value, usually after some command/operation.
     /// Also updates the EEPROM records accordingly
     /// @param newFilamentLoaded new state
-    void SetFilamentLoaded(uint8_t slot, FilamentLoadState newFilamentLoaded);
+    void __attribute__((noinline)) SetFilamentLoaded(uint8_t slot, FilamentLoadState newFilamentLoaded);
 
     /// @returns the total number of MMU errors so far
     /// Errors are stored in the EEPROM


### PR DESCRIPTION
The function is used very frequently throughout the project so I don't think it is a good idea to allow the function to be inlined.

Change in memory:
Flash: -130 bytes
SRAM: 0 bytes