### PR TITLE
optimisation: inline a few specific functions to reduce code size

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -35,7 +35,7 @@ Application::Application()
     , currentCommand(&logic::noCommand)
     , currentCommandRq(mp::RequestMsgCodes::Reset, 0) {}
 
-void Application::CheckManualOperation() {
+void __attribute__((noinline)) Application::CheckManualOperation() {
     uint16_t ms = mt::timebase.Millis();
     constexpr uint16_t idleDelay = 1000U;
     if (ms - lastCommandProcessedMs < idleDelay) {
@@ -102,7 +102,7 @@ void Application::ReportCommandAccepted(const mp::RequestMsg &rq, mp::ResponseMs
     modules::serial::WriteToUSART(tmp, len);
 }
 
-void Application::PlanCommand(const modules::protocol::RequestMsg &rq) {
+void __attribute__((noinline)) Application::PlanCommand(const modules::protocol::RequestMsg &rq) {
     if (currentCommand->State() == ProgressCode::OK) {
         // We are allowed to start a new command as the previous one is in the OK finished state
         // The previous command may be in an error state, but as long as it is in ProgressCode::OK (aka finished)

--- a/src/hal/tmc2130.cpp
+++ b/src/hal/tmc2130.cpp
@@ -108,7 +108,7 @@ void TMC2130::SetEnabled(const MotorParams &params, bool enabled) {
     this->enabled = enabled;
 }
 
-bool TMC2130::CheckForErrors(const MotorParams &params) {
+bool __attribute__((noinline)) TMC2130::CheckForErrors(const MotorParams &params) {
     if (!initialized)
         return false;
 

--- a/src/logic/command_base.cpp
+++ b/src/logic/command_base.cpp
@@ -39,7 +39,7 @@ static ErrorCode TMC2130ToErrorCode(const hal::tmc2130::ErrorFlags &ef) {
     return e;
 }
 
-static ErrorCode AddErrorAxisBit(ErrorCode ec, uint8_t tmcIndex) {
+static ErrorCode __attribute__((noinline)) AddErrorAxisBit(ErrorCode ec, uint8_t tmcIndex) {
     switch (tmcIndex) {
     case config::Axis::Pulley:
         ec |= ErrorCode::TMC_PULLEY_BIT;
@@ -205,13 +205,13 @@ void CommandBase::GoToErrDisengagingIdler(ErrorCode deferredEC) {
     mi::idler.Disengage();
 }
 
-void CommandBase::GoToErrEngagingIdler() {
+void __attribute__((noinline)) CommandBase::GoToErrEngagingIdler() {
     state = ProgressCode::ERREngagingIdler;
     error = ErrorCode::RUNNING;
     mi::idler.Engage(mg::globals.ActiveSlot());
 }
 
-void CommandBase::FinishedOK() {
+void __attribute__((noinline)) CommandBase::FinishedOK() {
     state = ProgressCode::OK;
     error = ErrorCode::OK;
     application.CommandFinishedCorrectly();

--- a/src/modules/movable_base.cpp
+++ b/src/modules/movable_base.cpp
@@ -32,7 +32,7 @@ MovableBase::OperationResult MovableBase::InitMovement() {
     }
 }
 
-MovableBase::OperationResult MovableBase::InitMovementNoReinitAxis() {
+MovableBase::OperationResult __attribute__((noinline)) MovableBase::InitMovementNoReinitAxis() {
     PrepareMoveToPlannedSlot();
     state = Moving;
     return OperationResult::Accepted;

--- a/src/modules/protocol.cpp
+++ b/src/modules/protocol.cpp
@@ -327,7 +327,7 @@ uint8_t Protocol::UInt8ToHex(uint8_t value, uint8_t *dst) {
     return charsOut;
 }
 
-uint8_t Protocol::UInt16ToHex(uint16_t value, uint8_t *dst) {
+uint8_t __attribute__((noinline)) Protocol::UInt16ToHex(uint16_t value, uint8_t *dst) {
     constexpr uint16_t topNibbleMask = 0xf000;
     if (value == 0) {
         *dst = '0';

--- a/src/modules/pulley.cpp
+++ b/src/modules/pulley.cpp
@@ -11,7 +11,7 @@ namespace pulley {
 
 Pulley pulley;
 
-bool Pulley::FinishHomingAndPlanMoveToParkPos() {
+bool __attribute__((noinline)) Pulley::FinishHomingAndPlanMoveToParkPos() {
     mm::motion.SetPosition(mm::Pulley, 0);
     return true;
 }
@@ -46,7 +46,7 @@ int32_t Pulley::CurrentPosition_mm() {
     return mm::axisUnitToTruncatedUnit<config::U_mm>(mm::motion.CurPosition<mm::Pulley>());
 }
 
-void Pulley::InitAxis() {
+void __attribute__((noinline)) Pulley::InitAxis() {
     mm::motion.InitAxis(mm::Pulley);
 }
 


### PR DESCRIPTION
Functions inlined here should not have any impact on timing sensitive code

Change in memory:
Flash: -394 bytes
SRAM: 0 bytes

**Before:**

```
Program:   28176 bytes (86.0% Full)
Data:       1778 bytes (69.5% Full)
```

**After:**

```
Program:   27782 bytes (84.8% Full)
Data:       1778 bytes (69.5% Full)
```