### PR TITLE
🚧 WIP: create library for application and link into all executables

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -9,9 +9,66 @@ include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)
 add_library(catch_main ${CMAKE_CURRENT_SOURCE_DIR}/test_main.cpp)
 target_link_libraries(catch_main Catch2::Catch2WithMain)
 
+set(MODULES_STUBS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/modules/stubs)
+set(LOGIC_STUBS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/logic/stubs)
+
+add_library(
+  application STATIC
+  ${CMAKE_SOURCE_DIR}/src/registers.cpp
+  ${CMAKE_SOURCE_DIR}/src/application.cpp
+  ${CMAKE_SOURCE_DIR}/src/modules/buttons.cpp
+  ${CMAKE_SOURCE_DIR}/src/modules/leds.cpp
+  ${CMAKE_SOURCE_DIR}/src/modules/globals.cpp
+  ${CMAKE_SOURCE_DIR}/src/modules/finda.cpp
+  ${CMAKE_SOURCE_DIR}/src/modules/debouncer.cpp
+  ${CMAKE_SOURCE_DIR}/src/modules/fsensor.cpp
+  ${CMAKE_SOURCE_DIR}/src/modules/idler.cpp
+  ${CMAKE_SOURCE_DIR}/src/modules/movable_base.cpp
+  ${CMAKE_SOURCE_DIR}/src/modules/permanent_storage.cpp
+  ${CMAKE_SOURCE_DIR}/src/modules/protocol.cpp
+  ${CMAKE_SOURCE_DIR}/src/modules/pulley.cpp
+  ${CMAKE_SOURCE_DIR}/src/modules/selector.cpp
+  ${CMAKE_SOURCE_DIR}/src/modules/user_input.cpp
+  ${CMAKE_SOURCE_DIR}/src/modules/pulse_gen.cpp
+  ${MODULES_STUBS_DIR}/stub_adc.cpp
+  ${MODULES_STUBS_DIR}/stub_cpu.cpp
+  ${MODULES_STUBS_DIR}/stub_eeprom.cpp
+  ${MODULES_STUBS_DIR}/stub_gpio.cpp
+  ${MODULES_STUBS_DIR}/stub_shr16.cpp
+  ${MODULES_STUBS_DIR}/stub_serial.cpp
+  ${MODULES_STUBS_DIR}/stub_timebase.cpp
+  ${MODULES_STUBS_DIR}/stub_tmc2130.cpp
+  ${LOGIC_STUBS_DIR}/homing.cpp
+  ${LOGIC_STUBS_DIR}/main_loop_stub.cpp
+  ${LOGIC_STUBS_DIR}/stub_motion.cpp
+  ${CMAKE_SOURCE_DIR}/src/logic/no_command.cpp
+  ${CMAKE_SOURCE_DIR}/src/logic/command_base.cpp
+  ${CMAKE_SOURCE_DIR}/src/logic/cut_filament.cpp
+  ${CMAKE_SOURCE_DIR}/src/logic/load_filament.cpp
+  ${CMAKE_SOURCE_DIR}/src/logic/move_selector.cpp
+  ${CMAKE_SOURCE_DIR}/src/logic/no_command.cpp
+  ${CMAKE_SOURCE_DIR}/src/logic/eject_filament.cpp
+  ${CMAKE_SOURCE_DIR}/src/logic/tool_change.cpp
+  ${CMAKE_SOURCE_DIR}/src/logic/unload_filament.cpp
+  ${CMAKE_SOURCE_DIR}/src/logic/home.cpp
+  ${CMAKE_SOURCE_DIR}/src/logic/set_mode.cpp
+  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_finda.cpp
+  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_bondtech.cpp
+  ${CMAKE_SOURCE_DIR}/src/logic/retract_from_finda.cpp
+  ${CMAKE_SOURCE_DIR}/src/logic/unload_to_finda.cpp
+  )
+
+# define required search paths
+target_include_directories(
+  application PRIVATE ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/src/modules
+                      ${CMAKE_SOURCE_DIR}/src/hal
+  )
+
+target_link_libraries(application catch_main Catch2::Catch2WithMain)
+
 # registers given target as a catch test
 function(add_catch_test target)
-  target_link_libraries(${target} catch_main Catch2::Catch2WithMain)
+  target_link_libraries(${target} catch_main Catch2::Catch2WithMain application)
   catch_discover_tests(${target})
   add_dependencies(tests ${target})
 endfunction()
@@ -19,12 +76,8 @@ endfunction()
 add_executable(system_tests ${CMAKE_CURRENT_SOURCE_DIR}/system_test.cpp)
 add_catch_test(system_tests)
 
-set(MODULES_STUBS_DIR ${CMAKE_SOURCE_DIR}/tests/unit/modules/stubs)
-set(LOGIC_STUBS_DIR ${CMAKE_SOURCE_DIR}/tests/unit/logic/stubs)
-
 # now, include all the unit tests; they should add themselves using the add_catch_test function
 add_subdirectory(hal)
 add_subdirectory(logic)
 add_subdirectory(modules)
-
 add_subdirectory(application)

--- a/tests/unit/application/CMakeLists.txt
+++ b/tests/unit/application/CMakeLists.txt
@@ -1,51 +1,5 @@
 # define the test executable
-add_executable(
-  application_tests
-  ${CMAKE_SOURCE_DIR}/src/registers.cpp
-  ${CMAKE_SOURCE_DIR}/src/application.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/buttons.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/leds.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/globals.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/debouncer.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/fsensor.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/idler.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/movable_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/permanent_storage.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/protocol.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulley.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/user_input.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulse_gen.cpp
-  ${MODULES_STUBS_DIR}/stub_adc.cpp
-  ${MODULES_STUBS_DIR}/stub_cpu.cpp
-  ${MODULES_STUBS_DIR}/stub_eeprom.cpp
-  ${MODULES_STUBS_DIR}/stub_gpio.cpp
-  ${MODULES_STUBS_DIR}/stub_shr16.cpp
-  ${MODULES_STUBS_DIR}/stub_serial.cpp
-  ${MODULES_STUBS_DIR}/stub_timebase.cpp
-  ${MODULES_STUBS_DIR}/stub_tmc2130.cpp
-  ${LOGIC_STUBS_DIR}/homing.cpp
-  ${LOGIC_STUBS_DIR}/main_loop_stub.cpp
-  ${LOGIC_STUBS_DIR}/stub_motion.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/no_command.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/command_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/cut_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/load_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/move_selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/no_command.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/eject_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/tool_change.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/home.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/set_mode.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_bondtech.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/retract_from_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_to_finda.cpp
-  test_registers.cpp
-  test_application.cpp
-  )
+add_executable(application_tests test_application.cpp test_registers.cpp)
 
 # define required search paths
 target_include_directories(

--- a/tests/unit/logic/cut_filament/CMakeLists.txt
+++ b/tests/unit/logic/cut_filament/CMakeLists.txt
@@ -1,49 +1,5 @@
 # define the test executable
-add_executable(
-  cut_filament_tests
-  ${CMAKE_SOURCE_DIR}/src/application.cpp
-  ${CMAKE_SOURCE_DIR}/src/registers.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/command_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/cut_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/eject_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_bondtech.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/home.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/load_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/move_selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/no_command.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/retract_from_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/set_mode.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/tool_change.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/buttons.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/debouncer.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/fsensor.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/globals.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/idler.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/leds.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/movable_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/permanent_storage.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/protocol.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulley.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/user_input.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulse_gen.cpp
-  ${MODULES_STUBS_DIR}/stub_adc.cpp
-  ${MODULES_STUBS_DIR}/stub_cpu.cpp
-  ${MODULES_STUBS_DIR}/stub_eeprom.cpp
-  ${MODULES_STUBS_DIR}/stub_gpio.cpp
-  ${MODULES_STUBS_DIR}/stub_shr16.cpp
-  ${MODULES_STUBS_DIR}/stub_serial.cpp
-  ${MODULES_STUBS_DIR}/stub_timebase.cpp
-  ${MODULES_STUBS_DIR}/stub_tmc2130.cpp
-  ${LOGIC_STUBS_DIR}/homing.cpp
-  ${LOGIC_STUBS_DIR}/main_loop_stub.cpp
-  ${LOGIC_STUBS_DIR}/stub_motion.cpp
-  test_cut_filament.cpp
-  )
+add_executable(cut_filament_tests test_cut_filament.cpp)
 
 # define required search paths
 target_include_directories(

--- a/tests/unit/logic/eject_filament/CMakeLists.txt
+++ b/tests/unit/logic/eject_filament/CMakeLists.txt
@@ -1,49 +1,5 @@
 # define the test executable
-add_executable(
-  eject_filament_tests
-  ${CMAKE_SOURCE_DIR}/src/application.cpp
-  ${CMAKE_SOURCE_DIR}/src/registers.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/command_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/cut_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/eject_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_bondtech.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/home.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/load_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/move_selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/no_command.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/retract_from_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/set_mode.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/tool_change.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/buttons.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/debouncer.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/fsensor.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/globals.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/idler.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/leds.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/movable_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/permanent_storage.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/protocol.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulley.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/user_input.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulse_gen.cpp
-  ${MODULES_STUBS_DIR}/stub_adc.cpp
-  ${MODULES_STUBS_DIR}/stub_cpu.cpp
-  ${MODULES_STUBS_DIR}/stub_eeprom.cpp
-  ${MODULES_STUBS_DIR}/stub_gpio.cpp
-  ${MODULES_STUBS_DIR}/stub_shr16.cpp
-  ${MODULES_STUBS_DIR}/stub_serial.cpp
-  ${MODULES_STUBS_DIR}/stub_timebase.cpp
-  ${MODULES_STUBS_DIR}/stub_tmc2130.cpp
-  ${LOGIC_STUBS_DIR}/homing.cpp
-  ${LOGIC_STUBS_DIR}/main_loop_stub.cpp
-  ${LOGIC_STUBS_DIR}/stub_motion.cpp
-  test_eject_filament.cpp
-  )
+add_executable(eject_filament_tests test_eject_filament.cpp)
 
 # define required search paths
 target_include_directories(

--- a/tests/unit/logic/failing_tmc/CMakeLists.txt
+++ b/tests/unit/logic/failing_tmc/CMakeLists.txt
@@ -1,49 +1,5 @@
 # define the test executable
-add_executable(
-  failing_tmc_tests
-  ${CMAKE_SOURCE_DIR}/src/application.cpp
-  ${CMAKE_SOURCE_DIR}/src/registers.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/command_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/cut_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/eject_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_bondtech.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/home.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/load_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/move_selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/no_command.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/retract_from_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/set_mode.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/tool_change.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/buttons.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/debouncer.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/fsensor.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/globals.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/idler.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/leds.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/movable_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/permanent_storage.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/protocol.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulley.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/user_input.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulse_gen.cpp
-  ${MODULES_STUBS_DIR}/stub_adc.cpp
-  ${MODULES_STUBS_DIR}/stub_cpu.cpp
-  ${MODULES_STUBS_DIR}/stub_eeprom.cpp
-  ${MODULES_STUBS_DIR}/stub_gpio.cpp
-  ${MODULES_STUBS_DIR}/stub_shr16.cpp
-  ${MODULES_STUBS_DIR}/stub_serial.cpp
-  ${MODULES_STUBS_DIR}/stub_timebase.cpp
-  ${MODULES_STUBS_DIR}/stub_tmc2130.cpp
-  ${LOGIC_STUBS_DIR}/homing.cpp
-  ${LOGIC_STUBS_DIR}/main_loop_stub.cpp
-  ${LOGIC_STUBS_DIR}/stub_motion.cpp
-  test_failing_tmc.cpp
-  )
+add_executable(failing_tmc_tests test_failing_tmc.cpp)
 
 # define required search paths
 target_include_directories(

--- a/tests/unit/logic/feed_to_bondtech/CMakeLists.txt
+++ b/tests/unit/logic/feed_to_bondtech/CMakeLists.txt
@@ -1,49 +1,5 @@
 # define the test executable
-add_executable(
-  feed_to_bondtech_tests
-  ${CMAKE_SOURCE_DIR}/src/application.cpp
-  ${CMAKE_SOURCE_DIR}/src/registers.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/command_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/cut_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/eject_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_bondtech.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/home.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/load_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/move_selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/no_command.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/retract_from_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/set_mode.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/tool_change.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/buttons.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/debouncer.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/fsensor.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/globals.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/idler.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/leds.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/movable_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/permanent_storage.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/protocol.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulley.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/user_input.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulse_gen.cpp
-  ${MODULES_STUBS_DIR}/stub_adc.cpp
-  ${MODULES_STUBS_DIR}/stub_cpu.cpp
-  ${MODULES_STUBS_DIR}/stub_eeprom.cpp
-  ${MODULES_STUBS_DIR}/stub_gpio.cpp
-  ${MODULES_STUBS_DIR}/stub_shr16.cpp
-  ${MODULES_STUBS_DIR}/stub_serial.cpp
-  ${MODULES_STUBS_DIR}/stub_timebase.cpp
-  ${MODULES_STUBS_DIR}/stub_tmc2130.cpp
-  ${LOGIC_STUBS_DIR}/homing.cpp
-  ${LOGIC_STUBS_DIR}/main_loop_stub.cpp
-  ${LOGIC_STUBS_DIR}/stub_motion.cpp
-  test_feed_to_bondtech.cpp
-  )
+add_executable(feed_to_bondtech_tests test_feed_to_bondtech.cpp)
 
 # define required search paths
 target_include_directories(

--- a/tests/unit/logic/feed_to_finda/CMakeLists.txt
+++ b/tests/unit/logic/feed_to_finda/CMakeLists.txt
@@ -1,49 +1,5 @@
 # define the test executable
-add_executable(
-  feed_to_finda_tests
-  ${CMAKE_SOURCE_DIR}/src/application.cpp
-  ${CMAKE_SOURCE_DIR}/src/registers.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/command_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/cut_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/eject_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_bondtech.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/home.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/load_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/move_selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/no_command.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/retract_from_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/set_mode.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/tool_change.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/buttons.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/debouncer.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/fsensor.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/globals.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/idler.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/leds.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/movable_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/permanent_storage.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/protocol.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulley.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/user_input.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulse_gen.cpp
-  ${MODULES_STUBS_DIR}/stub_adc.cpp
-  ${MODULES_STUBS_DIR}/stub_cpu.cpp
-  ${MODULES_STUBS_DIR}/stub_eeprom.cpp
-  ${MODULES_STUBS_DIR}/stub_gpio.cpp
-  ${MODULES_STUBS_DIR}/stub_shr16.cpp
-  ${MODULES_STUBS_DIR}/stub_serial.cpp
-  ${MODULES_STUBS_DIR}/stub_timebase.cpp
-  ${MODULES_STUBS_DIR}/stub_tmc2130.cpp
-  ${LOGIC_STUBS_DIR}/homing.cpp
-  ${LOGIC_STUBS_DIR}/main_loop_stub.cpp
-  ${LOGIC_STUBS_DIR}/stub_motion.cpp
-  test_feed_to_finda.cpp
-  )
+add_executable(feed_to_finda_tests test_feed_to_finda.cpp)
 
 # define required search paths
 target_include_directories(

--- a/tests/unit/logic/homing/CMakeLists.txt
+++ b/tests/unit/logic/homing/CMakeLists.txt
@@ -1,49 +1,5 @@
 # define the test executable
-add_executable(
-  homing_tests
-  ${CMAKE_SOURCE_DIR}/src/application.cpp
-  ${CMAKE_SOURCE_DIR}/src/registers.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/command_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/cut_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/eject_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_bondtech.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/home.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/load_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/move_selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/no_command.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/retract_from_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/set_mode.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/tool_change.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/buttons.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/debouncer.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/fsensor.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/globals.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/idler.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/leds.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/movable_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/permanent_storage.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/protocol.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulley.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/user_input.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulse_gen.cpp
-  ${MODULES_STUBS_DIR}/stub_adc.cpp
-  ${MODULES_STUBS_DIR}/stub_cpu.cpp
-  ${MODULES_STUBS_DIR}/stub_eeprom.cpp
-  ${MODULES_STUBS_DIR}/stub_gpio.cpp
-  ${MODULES_STUBS_DIR}/stub_shr16.cpp
-  ${MODULES_STUBS_DIR}/stub_serial.cpp
-  ${MODULES_STUBS_DIR}/stub_timebase.cpp
-  ${MODULES_STUBS_DIR}/stub_tmc2130.cpp
-  ${LOGIC_STUBS_DIR}/homing.cpp
-  ${LOGIC_STUBS_DIR}/main_loop_stub.cpp
-  ${LOGIC_STUBS_DIR}/stub_motion.cpp
-  test_homing.cpp
-  )
+add_executable(homing_tests test_homing.cpp)
 
 # define required search paths
 target_include_directories(

--- a/tests/unit/logic/load_filament/CMakeLists.txt
+++ b/tests/unit/logic/load_filament/CMakeLists.txt
@@ -1,50 +1,5 @@
 # define the test executable
-add_executable(
-  load_filament_tests
-  ${CMAKE_SOURCE_DIR}/src/application.cpp
-  ${CMAKE_SOURCE_DIR}/src/registers.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/command_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/cut_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/eject_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_bondtech.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/home.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/load_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/move_selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/no_command.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/retract_from_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/set_mode.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/tool_change.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/buttons.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/debouncer.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/fsensor.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/globals.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/idler.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/leds.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/movable_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/permanent_storage.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/protocol.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulley.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/user_input.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulse_gen.cpp
-  ${MODULES_STUBS_DIR}/stub_adc.cpp
-  ${MODULES_STUBS_DIR}/stub_cpu.cpp
-  ${MODULES_STUBS_DIR}/stub_eeprom.cpp
-  ${MODULES_STUBS_DIR}/stub_gpio.cpp
-  ${MODULES_STUBS_DIR}/stub_shr16.cpp
-  ${MODULES_STUBS_DIR}/stub_serial.cpp
-  ${MODULES_STUBS_DIR}/stub_timebase.cpp
-  ${MODULES_STUBS_DIR}/stub_tmc2130.cpp
-  ${LOGIC_STUBS_DIR}/homing.cpp
-  ${LOGIC_STUBS_DIR}/main_loop_stub.cpp
-  ${LOGIC_STUBS_DIR}/stub_motion.cpp
-  test_load_filament.cpp
-  )
+add_executable(load_filament_tests test_load_filament.cpp)
 
 # define required search paths
 target_include_directories(

--- a/tests/unit/logic/tool_change/CMakeLists.txt
+++ b/tests/unit/logic/tool_change/CMakeLists.txt
@@ -1,50 +1,5 @@
 # define the test executable
-add_executable(
-  tool_change_tests
-  ${CMAKE_SOURCE_DIR}/src/application.cpp
-  ${CMAKE_SOURCE_DIR}/src/registers.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/command_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/cut_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/eject_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_bondtech.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/home.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/load_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/move_selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/no_command.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/retract_from_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/set_mode.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/tool_change.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/buttons.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/debouncer.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/fsensor.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/globals.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/idler.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/leds.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/movable_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/permanent_storage.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/protocol.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulley.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/user_input.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulse_gen.cpp
-  ${MODULES_STUBS_DIR}/stub_adc.cpp
-  ${MODULES_STUBS_DIR}/stub_cpu.cpp
-  ${MODULES_STUBS_DIR}/stub_eeprom.cpp
-  ${MODULES_STUBS_DIR}/stub_gpio.cpp
-  ${MODULES_STUBS_DIR}/stub_shr16.cpp
-  ${MODULES_STUBS_DIR}/stub_serial.cpp
-  ${MODULES_STUBS_DIR}/stub_timebase.cpp
-  ${MODULES_STUBS_DIR}/stub_tmc2130.cpp
-  ${LOGIC_STUBS_DIR}/homing.cpp
-  ${LOGIC_STUBS_DIR}/main_loop_stub.cpp
-  ${LOGIC_STUBS_DIR}/stub_motion.cpp
-  test_tool_change.cpp
-  )
+add_executable(tool_change_tests test_tool_change.cpp)
 
 # define required search paths
 target_include_directories(

--- a/tests/unit/logic/unload_filament/CMakeLists.txt
+++ b/tests/unit/logic/unload_filament/CMakeLists.txt
@@ -1,49 +1,5 @@
 # define the test executable
-add_executable(
-  unload_filament_tests
-  ${CMAKE_SOURCE_DIR}/src/application.cpp
-  ${CMAKE_SOURCE_DIR}/src/registers.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/command_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/cut_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/eject_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_bondtech.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/home.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/load_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/move_selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/no_command.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/retract_from_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/set_mode.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/tool_change.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/buttons.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/debouncer.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/fsensor.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/globals.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/idler.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/leds.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/movable_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/permanent_storage.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/protocol.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulley.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/user_input.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulse_gen.cpp
-  ${MODULES_STUBS_DIR}/stub_adc.cpp
-  ${MODULES_STUBS_DIR}/stub_cpu.cpp
-  ${MODULES_STUBS_DIR}/stub_eeprom.cpp
-  ${MODULES_STUBS_DIR}/stub_gpio.cpp
-  ${MODULES_STUBS_DIR}/stub_shr16.cpp
-  ${MODULES_STUBS_DIR}/stub_serial.cpp
-  ${MODULES_STUBS_DIR}/stub_timebase.cpp
-  ${MODULES_STUBS_DIR}/stub_tmc2130.cpp
-  ${LOGIC_STUBS_DIR}/homing.cpp
-  ${LOGIC_STUBS_DIR}/main_loop_stub.cpp
-  ${LOGIC_STUBS_DIR}/stub_motion.cpp
-  test_unload_filament.cpp
-  )
+add_executable(unload_filament_tests test_unload_filament.cpp)
 
 # define required search paths
 target_include_directories(

--- a/tests/unit/logic/unload_to_finda/CMakeLists.txt
+++ b/tests/unit/logic/unload_to_finda/CMakeLists.txt
@@ -1,49 +1,5 @@
 # define the test executable
-add_executable(
-  unload_to_finda_tests
-  ${CMAKE_SOURCE_DIR}/src/application.cpp
-  ${CMAKE_SOURCE_DIR}/src/registers.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/command_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/cut_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/eject_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/feed_to_bondtech.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/home.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/load_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/move_selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/no_command.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/retract_from_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/set_mode.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/tool_change.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_filament.cpp
-  ${CMAKE_SOURCE_DIR}/src/logic/unload_to_finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/buttons.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/debouncer.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/finda.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/fsensor.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/globals.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/idler.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/leds.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/movable_base.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/permanent_storage.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/protocol.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulley.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/selector.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/user_input.cpp
-  ${CMAKE_SOURCE_DIR}/src/modules/pulse_gen.cpp
-  ${MODULES_STUBS_DIR}/stub_adc.cpp
-  ${MODULES_STUBS_DIR}/stub_cpu.cpp
-  ${MODULES_STUBS_DIR}/stub_eeprom.cpp
-  ${MODULES_STUBS_DIR}/stub_gpio.cpp
-  ${MODULES_STUBS_DIR}/stub_shr16.cpp
-  ${MODULES_STUBS_DIR}/stub_serial.cpp
-  ${MODULES_STUBS_DIR}/stub_timebase.cpp
-  ${MODULES_STUBS_DIR}/stub_tmc2130.cpp
-  ${LOGIC_STUBS_DIR}/homing.cpp
-  ${LOGIC_STUBS_DIR}/main_loop_stub.cpp
-  ${LOGIC_STUBS_DIR}/stub_motion.cpp
-  test_unload_to_finda.cpp
-  )
+add_executable(unload_to_finda_tests test_unload_to_finda.cpp)
 
 # define required search paths
 target_include_directories(


### PR DESCRIPTION
Just an idea I'm playing with.

Currently it takes around 60 seconds and 640 steps to compile and link the unit tests.

With this PR I've reduced it to 40 seconds and 231 steps.


`[build] [639/640  99% :: 63.743] Linking CXX executable tests\unit\logic\failing_tmc\failing_tmc_tests.exe`