### PR TITLE
Bump prusa3dboards and don't build with debug symbols when using VScode

### DIFF
--- a/.vscode/cmake-kits.json
+++ b/.vscode/cmake-kits.json
@@ -1,9 +1,10 @@
 [
     {
-        "name": "Local_avr-gcc-none-eabi",
+        "name": "avr-gcc",
         "toolchainFile": "${workspaceFolder}/cmake/AvrGcc.cmake",
         "cmakeSettings": {
-            "CMAKE_MAKE_PROGRAM": "${workspaceFolder}/.dependencies/ninja-1.10.2/ninja"
+            "CMAKE_MAKE_PROGRAM": "${workspaceFolder}/.dependencies/ninja-1.10.2/ninja",
+            "CMAKE_BUILD_TYPE": "Release"
         }
     }
 ]

--- a/utils/bootstrap.py
+++ b/utils/bootstrap.py
@@ -60,8 +60,12 @@ dependencies = {
         }
     },
     'prusa3dboards': {
-        'version': '1.0.5-2',
-        'url':'https://raw.githubusercontent.com/prusa3d/Arduino_Boards/devel/IDE_Board_Manager/prusa3dboards-1.0.5-2.tar.bz2',
+        'version': '1.0.6',
+        'url': {
+            'Linux': 'https://raw.githubusercontent.com/prusa3d/Arduino_Boards/master/IDE_Board_Manager/prusa3dboards-1.0.6.tar.bz2',
+            'Windows': 'https://raw.githubusercontent.com/prusa3d/Arduino_Boards/master/IDE_Board_Manager/prusa3dboards-1.0.6.tar.bz2',
+            'Darwin': 'https://raw.githubusercontent.com/prusa3d/Arduino_Boards/master/IDE_Board_Manager/prusa3dboards-1.0.6.tar.bz2',
+        }
     },
 }
 pip_dependencies = []


### PR DESCRIPTION
- Bump prusa3dboards package
- Set CMake Build Type to Release, otherwise building with this kit doesn't work (debug symbols don't fit)
-  Rename kit to be same as on MK3 firmware