### PR TITLE
MMU EEPROM reset support

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -184,39 +184,39 @@ void Application::ReportWriteRegister(const mp::RequestMsg &rq) {
 /// Intended only for visualization of EEPROM reset, not to be used in while the MMU is running normally
 namespace EEPROMResetVis {
 
-static void Delay(){
+static void Delay() {
     uint32_t start = mt::timebase.Millis();
-    while( ! mt::timebase.Elapsed(start, 100) ){
+    while (!mt::timebase.Elapsed(start, 50)) {
         ml::leds.Step();
     }
 }
 
-static void __attribute__((noinline)) Green(uint8_t i){
+static void __attribute__((noinline)) Green(uint8_t i) {
     ml::leds.SetPairButOffOthers(i, ml::on, ml::off);
     Delay();
 }
 
-static void __attribute__((noinline)) Red(uint8_t i){
-    ml::leds.SetPairButOffOthers(i, ml::on, ml::off);
+static void __attribute__((noinline)) Red(uint8_t i) {
+    ml::leds.SetPairButOffOthers(i, ml::off, ml::on);
     Delay();
 }
 
-static void Run(){
-    for(uint8_t i = 0; i < ml::leds.LedPairsCount(); ++i){
-        Green(i);
+static void Run() {
+    for (uint8_t i = 0; i < ml::leds.LedPairsCount(); ++i) {
         Red(i);
+        Green(i);
     }
-    for(uint8_t i = ml::leds.LedPairsCount(); i != 0; --i){
-        Red(i);
+    for (uint8_t i = ml::leds.LedPairsCount(); i != 0; --i) {
         Green(i);
+        Red(i);
     }
 }
 
 } // namespace EEPROMResetVis
 
-void Application::ProcessReset(uint8_t resetType){
-    switch(resetType){
-    case 42: // perform an EEPROM reset if the resetType == The Answer to the Ultimate Question of Life, the Universe, and Everything :)
+void Application::ProcessReset(ResetTypes resetType) {
+    switch (resetType) {
+    case ResetTypes::EEPROMAndSoftware: // perform an EEPROM reset if the resetType == The Answer to the Ultimate Question of Life, the Universe, and Everything :)
         mps::EraseAll();
         EEPROMResetVis::Run();
         [[fallthrough]];
@@ -242,7 +242,7 @@ void Application::ProcessRequestMsg(const mp::RequestMsg &rq) {
         break;
     case mp::RequestMsgCodes::Reset:
         // immediately reset the board - there is no response in this case
-        ProcessReset(rq.value);
+        ProcessReset((ResetTypes)rq.value);
         break;
     case mp::RequestMsgCodes::Version:
     case mp::RequestMsgCodes::Read:

--- a/src/application.h
+++ b/src/application.h
@@ -26,6 +26,16 @@ public:
     uint8_t CurrentProgressCode();
     uint16_t CurrentErrorCode();
 
+    /// Types of Reset parameters
+    enum class ResetTypes : uint8_t {
+        Software = 0,
+        EEPROMAndSoftware = 42,
+    };
+
+    /// Performs a reset of the MMU board.
+    /// @param resetType == EEPROMAndSoftware, the EEPROM is cleared before resetting the board. Otherwise the MMU board "just" resets.
+    void ProcessReset(ResetTypes resetType);
+
 #ifndef UNITTEST
 private:
 #endif
@@ -46,7 +56,6 @@ private:
     void ReportReadRegister(const mp::RequestMsg &rq);
     void ReportWriteRegister(const mp::RequestMsg &rq);
     void ProcessRequestMsg(const mp::RequestMsg &rq);
-    void ProcessReset(uint8_t resetType);
 
     uint16_t lastCommandProcessedMs;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,13 +82,16 @@ static void setup() {
     ml::leds.Step();
 
     mu::cdc.Init();
+
+    mb::buttons.Step();
 }
 
 /// Second part of setup - executed with interrupts enabled
 static void setup2() {
     // waits at least finda debounce period
-    // which is abused to let the LEDs shine for ~100ms
+    // which is abused to let the LEDs shine for ~100ms and let the buttons "debounce" during that period
     mf::finda.BlockingInit();
+    mb::buttons.Step();
 
     // Turn off all leds
     for (uint8_t i = 0; i < config::toolCount; i++) {
@@ -96,6 +99,13 @@ static void setup2() {
         ml::leds.SetMode(i, ml::red, ml::off);
     }
     ml::leds.Step();
+    mb::buttons.Step();
+
+    // Check left button pressed -> EEPROM reset - we cannot reliably check for multiple buttons due to electrical design
+    if (mb::buttons.ButtonPressed(mb::Left)) {
+        application.ProcessReset(Application::ResetTypes::EEPROMAndSoftware);
+        // note: there is no need to perform anything else, ProcessReset will just reboot the board
+    }
 
     // Prep hardware sanity:
     logic::hwSanity.Reset(0);


### PR DESCRIPTION
- [x] HW solution:
Holding the LEFT button on the MMU before the selftest will trigger a comple EEPROM erase (As noted by @leptun, we cannot reliably check for >1 buttons pressed at once.). Since the left button is the least used, let's use it for invoking the HW EEPROM clear upon MMU start.
The MMU will perform a snake effect on the LEDs and then restart.
If there was a faulty unit having all the buttons pressed continously, such a unit will end up in a boot loop only doing the snake LED pattern.

- [x] SW solution
`X0` command on the protocol has been hijacked to perform an EEPROM reset as well if the value is correct.
The "ultimate" value has been chosen as `42`, i.e. sending `X2a` should erase the whole EEPROM and the MMU will restart.

MMU-193

CPU FLASH: +178B