### PR TITLE
Idler+Selector homing speeds: writeable registers

### DIFF
--- a/src/logic/cut_filament.cpp
+++ b/src/logic/cut_filament.cpp
@@ -110,7 +110,7 @@ bool CutFilament::StepInner() {
             ms::selector.SetCurrents(mg::globals.CutIRunCurrent(), config::selector.iHold);
             // lower move speed
             savedSelectorFeedRate_mm_s = mg::globals.SelectorFeedrate_mm_s().v;
-            mg::globals.SetSelectorFeedrate_mm_s(config::selectorHomingFeedrate.v);
+            mg::globals.SetSelectorFeedrate_mm_s(mg::globals.SelectorHomingFeedrate_mm_s().v);
             MoveSelector(cutSlot); // let it cut :)
         }
         break;

--- a/src/modules/globals.cpp
+++ b/src/modules/globals.cpp
@@ -30,8 +30,10 @@ void Globals::Init() {
     ResetPulleyUnloadFeedrate();
 
     ResetSelectorFeedrate();
+    ResetSelectorHomingFeedrate();
 
     ResetIdlerFeedrate();
+    ResetIdlerHomingFeedrate();
 
     ResetCutIRunCurrent();
 }

--- a/src/modules/globals.h
+++ b/src/modules/globals.h
@@ -91,6 +91,14 @@ public:
     void ResetIdlerFeedrate() { idlerFeedrate_deg_s = config::idlerFeedrate.v; }
     void SetIdlerFeedrate_deg_s(uint16_t idlerFR_deg_s) { idlerFeedrate_deg_s = idlerFR_deg_s; }
 
+    config::U_mm_s SelectorHomingFeedrate_mm_s() const { return config::U_mm_s({ (long double)selectorHomingFeedrate_mm_s }); }
+    void ResetSelectorHomingFeedrate() { selectorHomingFeedrate_mm_s = config::selectorHomingFeedrate.v; }
+    void SetSelectorHomingFeedrate_mm_s(uint16_t selectorFR_mm_s) { selectorHomingFeedrate_mm_s = selectorFR_mm_s; }
+
+    config::U_deg_s IdlerHomingFeedrate_deg_s() const { return config::U_deg_s({ (long double)idlerHomingFeedrate_deg_s }); }
+    void ResetIdlerHomingFeedrate() { idlerHomingFeedrate_deg_s = config::idlerHomingFeedrate.v; }
+    void SetIdlerHomingFeedrate_deg_s(uint16_t idlerFR_deg_s) { idlerHomingFeedrate_deg_s = idlerFR_deg_s; }
+
     /// @returns current StallGuard threshold for an axis
     uint8_t StallGuardThreshold(config::Axis axis) const;
     /// Stores the new StallGuard threshold for an axis into EEPROM (does not affect the current state of TMC drivers at all)
@@ -118,8 +126,10 @@ private:
     uint16_t pulleyUnloadFeedrate_mm_s;
 
     uint16_t selectorFeedrate_mm_s;
+    uint16_t selectorHomingFeedrate_mm_s;
 
     uint16_t idlerFeedrate_deg_s;
+    uint16_t idlerHomingFeedrate_deg_s;
 
     uint8_t cutIRunCurrent;
 };

--- a/src/modules/idler.cpp
+++ b/src/modules/idler.cpp
@@ -21,7 +21,7 @@ void Idler::PrepareMoveToPlannedSlot() {
 
 void Idler::PlanHomingMoveForward() {
     mm::motion.PlanMove<mm::Idler>(mm::unitToAxisUnit<mm::I_pos_t>(config::idlerLimits.lenght * 2),
-        mm::unitToAxisUnit<mm::I_speed_t>(config::idlerHomingFeedrate));
+        mm::unitToAxisUnit<mm::I_speed_t>(mg::globals.IdlerHomingFeedrate_deg_s()));
     dbg_logic_P(PSTR("Plan Homing Idler Forward"));
 }
 
@@ -30,7 +30,7 @@ void Idler::PlanHomingMoveBack() {
     mm::motion.SetPosition(mm::Idler, mm::unitToSteps<mm::I_pos_t>(config::idlerLimits.lenght));
     axisStart = mm::axisUnitToTruncatedUnit<config::U_deg>(mm::motion.CurPosition<mm::Idler>());
     mm::motion.PlanMove<mm::Idler>(mm::unitToAxisUnit<mm::I_pos_t>(-config::idlerLimits.lenght * 2),
-        mm::unitToAxisUnit<mm::I_speed_t>(config::idlerHomingFeedrate));
+        mm::unitToAxisUnit<mm::I_speed_t>(mg::globals.IdlerHomingFeedrate_deg_s()));
     dbg_logic_P(PSTR("Plan Homing Idler Back"));
 }
 

--- a/src/modules/selector.cpp
+++ b/src/modules/selector.cpp
@@ -29,7 +29,7 @@ void Selector::PlanHomingMoveBack() {
     mm::motion.SetPosition(mm::Selector, 0);
     axisStart = mm::axisUnitToTruncatedUnit<config::U_mm>(mm::motion.CurPosition<mm::Selector>());
     mm::motion.PlanMove<mm::Selector>(mm::unitToAxisUnit<mm::S_pos_t>(config::selectorLimits.lenght * 2),
-        mm::unitToAxisUnit<mm::S_speed_t>(config::selectorHomingFeedrate));
+        mm::unitToAxisUnit<mm::S_speed_t>(mg::globals.SelectorHomingFeedrate_mm_s()));
     dbg_logic_P(PSTR("Plan Homing Selector Back"));
 }
 
@@ -107,7 +107,7 @@ bool Selector::Step() {
             // idler is ok, we can start homing the selector
             state = HomeForward;
             mm::motion.PlanMove<mm::Selector>(mm::unitToAxisUnit<mm::S_pos_t>(-config::selectorLimits.lenght * 2),
-                mm::unitToAxisUnit<mm::S_speed_t>(config::selectorHomingFeedrate));
+                mm::unitToAxisUnit<mm::S_speed_t>(mg::globals.SelectorHomingFeedrate_mm_s()));
         }
         return false;
     case HomeForward:

--- a/src/registers.cpp
+++ b/src/registers.cpp
@@ -151,8 +151,8 @@
 | 0x12h 18 | uint16   | Selector_nominal_feedrate  | 0000h 0      | 002dh 45    | unit mm/s                                | Read / Write | M707 A0x12 | M708 A0x12 Xnnnn
 | 0x13h 19 | uint16   | Idler_nominal_feedrate     | 0000h 0      | 012ch 300   | unit deg/s                               | Read / Write | M707 A0x13 | M708 A0x13 Xnnnn
 | 0x14h 20 | uint16   | Pulley_slow_feedrate       | 0000h 0      | 0014h 20    | unit mm/s                                | Read / Write | M707 A0x14 | M708 A0x14 Xnnnn
-| 0x15h 21 | uint16   | Selector_homing_feedrate   | 0000h 0      | 001eh 30    | unit mm/s                                | Read (Write) | M707 A0x15 | (M708 A0x15 Xnnnn)
-| 0x16h 22 | uint16   | Idler_homing_feedrate      | 0000h 0      | 0109h 265   | unit deg/s                               | Read (Write) | M707 A0x16 | (M708 A0x16 Xnnnn)
+| 0x15h 21 | uint16   | Selector_homing_feedrate   | 0000h 0      | 001eh 30    | unit mm/s                                | Read / Write | M707 A0x15 | (M708 A0x15 Xnnnn)
+| 0x16h 22 | uint16   | Idler_homing_feedrate      | 0000h 0      | 0109h 265   | unit deg/s                               | Read / Write | M707 A0x16 | (M708 A0x16 Xnnnn)
 | 0x17h 23 | uint8    | Pulley_sg_thrs__R          | 00h 0        | 08h 8       |                                          | Read / Write Persistent | M707 A0x17 | M708 A0x17 Xnn
 | 0x18h 24 | uint8    | Selector_sg_thrs_R         | 00h 0        | 03h 3       |                                          | Read / Write Persistent | M707 A0x18 | M708 A0x18 Xnn
 | 0x19h 25 | uint8    | Idler_sg_thrs_R            | 00h 0        | 06h 6       |                                          | Read / Write Persistent | M707 A0x19 | M708 A0x19 Xnn
@@ -334,13 +334,13 @@ static const RegisterRec registers[] /*PROGMEM*/ = {
         2),
     // 0x15 Selector homing feedrate [mm/s] RW
     RegisterRec(
-        []() -> uint16_t { return config::selectorHomingFeedrate.v; },
-        //@@TODO please update documentation as well
+        []() -> uint16_t { return mg::globals.SelectorHomingFeedrate_mm_s().v; },
+        [](uint16_t d) { mg::globals.SetSelectorHomingFeedrate_mm_s(d); },
         2),
     // 0x16 Idler homing feedrate [deg/s] RW
     RegisterRec(
-        []() -> uint16_t { return config::idlerHomingFeedrate.v; },
-        //@@TODO please update documentation as well
+        []() -> uint16_t { return mg::globals.IdlerHomingFeedrate_deg_s().v; },
+        [](uint16_t d) { mg::globals.SetIdlerHomingFeedrate_deg_s(d); },
         2),
 
     // 0x17 Pulley sg_thrs threshold RW

--- a/version.cmake
+++ b/version.cmake
@@ -10,6 +10,6 @@ set(PROJECT_VERSION_MINOR
     CACHE STRING "Project minor version" FORCE
     )
 set(PROJECT_VERSION_REV
-    7
+    8
     CACHE STRING "Project revision" FORCE
     )


### PR DESCRIPTION
It looks like tweaking homing (especially Idler) really needs playing with the homing speeds as well. Now settable via registers which have been read-only before this change.

Increases version to 2.1.8 due to this change.

Related to https://github.com/prusa3d/Prusa-Firmware/pull/4060

MMU-218