### PR TITLE
Hold Idler and Selector even in logic::StartUp error handling

### DIFF
--- a/src/logic/start_up.cpp
+++ b/src/logic/start_up.cpp
@@ -11,6 +11,7 @@ StartUp startUp;
 
 bool StartUp::Reset(uint8_t) {
     if (!CheckFINDAvsEEPROM()) {
+        HoldIdlerSelector();
         SetInitError(ErrorCode::FINDA_VS_EEPROM_DISREPANCY);
     }
 
@@ -33,6 +34,7 @@ bool StartUp::StepInner() {
                     error = ErrorCode::FINDA_VS_EEPROM_DISREPANCY;
                     state = ProgressCode::ERRWaitingForUser;
                 } else {
+                    ResumeIdlerSelector();
                     error = ErrorCode::OK;
                     state = ProgressCode::OK;
                 }


### PR DESCRIPTION
StartUp doesn't share the common ErrDisengageIdler code so the hold/resume must be used explicitly.

- [x] needs verification on a real unit

MMU-217