### PR TITLE
logic: eject_filament: reset LED state on OK event

### DIFF
--- a/src/logic/eject_filament.cpp
+++ b/src/logic/eject_filament.cpp
@@ -80,7 +80,7 @@ bool EjectFilament::StepInner() {
             ResumeIdlerSelector();
             switch (error) {
             case ErrorCode::FILAMENT_EJECTED: // the user clicked "Done", we can finish the Eject operation
-                ml::leds.SetPairButOffOthers(mg::globals.ActiveSlot(), ml::off, ml::off);
+                ml::leds.SetAllOff();
                 FinishedOK();
                 break;
             case ErrorCode::FINDA_FLICKERS:

--- a/src/logic/hw_sanity.cpp
+++ b/src/logic/hw_sanity.cpp
@@ -97,9 +97,7 @@ bool HWSanity::StepInner() {
         } else {
             state = ProgressCode::HWTestExec;
             // display done, reset LEDs.
-            for (uint8_t i = 0; i < 6; i++) {
-                ml::leds.SetMode(i, ml::off);
-            }
+            ml::leds.SetAllOff();
         }
         [[fallthrough]];
     case ProgressCode::HWTestExec: {
@@ -163,7 +161,7 @@ bool HWSanity::StepInner() {
             ml::leds.SetMode(4, ml::green, ml::off);
             return true;
         } else {
-            ml::leds.SetPairButOffOthers(0, ml::off, ml::off);
+            ml::leds.SetAllOff();
             FinishedOK();
         }
     case ProgressCode::OK:

--- a/src/logic/load_filament.cpp
+++ b/src/logic/load_filament.cpp
@@ -64,7 +64,7 @@ void logic::LoadFilament::GoToRetractingFromFinda() {
 
 void logic::LoadFilament::LoadFinishedCorrectly() {
     FinishedOK();
-    ml::leds.SetPairButOffOthers(mg::globals.ActiveSlot(), ml::off, ml::off);
+    ml::leds.SetAllOff();
     mpu::pulley.Disable();
 }
 

--- a/src/logic/unload_filament.cpp
+++ b/src/logic/unload_filament.cpp
@@ -29,7 +29,7 @@ bool UnloadFilament::Reset(uint8_t /*param*/) {
     state = ProgressCode::UnloadingToFinda;
     error = ErrorCode::RUNNING;
     unl.Reset(maxRetries);
-    ml::leds.SetPairButOffOthers(mg::globals.ActiveSlot(), ml::off, ml::off);
+    ml::leds.SetAllOff();
     return true;
 }
 
@@ -37,7 +37,7 @@ void UnloadFilament::UnloadFinishedCorrectly() {
     FinishedOK();
     mpu::pulley.Disable();
     mg::globals.SetFilamentLoaded(mg::globals.ActiveSlot(), mg::FilamentLoadState::AtPulley); // filament unloaded
-    ml::leds.SetPairButOffOthers(mg::globals.ActiveSlot(), ml::off, ml::off);
+    ml::leds.SetAllOff();
 }
 
 void UnloadFilament::GoToRetractingFromFinda() {

--- a/src/modules/leds.cpp
+++ b/src/modules/leds.cpp
@@ -56,12 +56,16 @@ void LEDs::Step() {
 }
 
 void LEDs::SetPairButOffOthers(uint8_t activeSlot, ml::Mode greenMode, ml::Mode redMode) {
+    SetAllOff();
+    SetMode(activeSlot, ml::green, greenMode);
+    SetMode(activeSlot, ml::red, redMode);
+}
+
+void LEDs::SetAllOff() {
     for (uint8_t i = 0; i < ledPairs; ++i) {
         SetMode(i, ml::green, ml::off);
         SetMode(i, ml::red, ml::off);
     }
-    SetMode(activeSlot, ml::green, greenMode);
-    SetMode(activeSlot, ml::red, redMode);
 }
 
 } // namespace leds

--- a/src/modules/leds.h
+++ b/src/modules/leds.h
@@ -119,6 +119,9 @@ public:
     /// Sets active slot LEDs to some mode and turns off all the others
     void SetPairButOffOthers(uint8_t activeSlot, modules::leds::Mode greenMode, modules::leds::Mode redMode);
 
+    /// Turn off all LEDs
+    void SetAllOff();
+
 private:
     constexpr static const uint8_t ledPairs = config::toolCount;
     /// pairs of LEDs:


### PR DESCRIPTION
Fix a minor issue where once the `FILAMENT_EJECTED` error screen is shown on the MK3S+, the LEDs will stay blinking red even after the user has removed the filament and clicked "Done". Note that the issue only appears after having loaded a filament or unloaded it once. Otherwise after boot-up, the LED of the ejected filament is not illuminated since the active slot is never set.

My proposal is to turn the LED off.

Steps to reproduce:
1. Boot up printer and MMU in a clean state
2. MK3S+: on the LCD click "Load to Nozzle"
3. Once the loading is done, click "Unload filament"
4. Once unloading is done, click "Eject filament"
5. `FILAMENT_EJECTED` MMU error screen appears on the printer's UI

![IMG_3232](https://user-images.githubusercontent.com/8218499/235365290-832a7635-0567-420c-86d9-9ec661e11ef5.jpg)

6. Remove the filament and select "Done".
* **Expected behavior:** Blinking red LED turns off (or goes green).
* **Actual behavior:** LED continous to blink red with no error screen.

Change in memory:
Flash: -48 bytes
SRAM: 0 bytes