### PR TITLE
Remove redundant call to SetPairButOffOthers

### DIFF
--- a/src/logic/load_filament.cpp
+++ b/src/logic/load_filament.cpp
@@ -56,7 +56,6 @@ void logic::LoadFilament::Reset2(bool feedPhaseLimited) {
 }
 
 void logic::LoadFilament::GoToRetractingFromFinda() {
-    ml::leds.SetPairButOffOthers(mg::globals.ActiveSlot(), ml::blink0, ml::off);
     state = ProgressCode::RetractingFromFinda;
     error = ErrorCode::RUNNING;
     retract.Reset();

--- a/src/logic/retract_from_finda.cpp
+++ b/src/logic/retract_from_finda.cpp
@@ -13,7 +13,7 @@ namespace logic {
 void RetractFromFinda::Reset() {
     dbg_logic_P(PSTR("\nRetract from FINDA\n\n"));
     state = EngagingIdler;
-    ml::leds.SetMode(mg::globals.ActiveSlot(), ml::green, ml::blink0);
+    ml::leds.SetPairButOffOthers(mg::globals.ActiveSlot(), ml::blink0, ml::off);
     mi::idler.Engage(mg::globals.ActiveSlot());
 }
 


### PR DESCRIPTION
`retract.Reset()` takes care of setting the green LED to blink. Might as well turn of the red LED during reset just in case.

Change in memory:
Flash: -30 bytes
SRAM: 0 bytes