### PR TITLE
cleanup: unit tests: Remove unused Catch namespace

### DIFF
--- a/tests/unit/hal/circular_buffer/test_circular_buffer.cpp
+++ b/tests/unit/hal/circular_buffer/test_circular_buffer.cpp
@@ -1,8 +1,5 @@
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_vector.hpp"
 #include "circular_buffer.h"
-
-using Catch::Matchers::Equals;
 
 TEST_CASE("circular_buffer::basic", "[circular_buffer]") {
 

--- a/tests/unit/hal/progmem/test_progmem.cpp
+++ b/tests/unit/hal/progmem/test_progmem.cpp
@@ -1,8 +1,6 @@
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_vector.hpp"
 #include "progmem.h"
 
-using Catch::Matchers::Equals;
 namespace pm = hal::progmem;
 
 TEST_CASE("progmem::read_word", "[progmem]") {

--- a/tests/unit/logic/cut_filament/test_cut_filament.cpp
+++ b/tests/unit/logic/cut_filament/test_cut_filament.cpp
@@ -1,5 +1,4 @@
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_vector.hpp"
 
 #include "../../../../src/modules/buttons.h"
 #include "../../../../src/modules/finda.h"
@@ -18,8 +17,6 @@
 #include "../stubs/homing.h"
 #include "../stubs/main_loop_stub.h"
 #include "../stubs/stub_motion.h"
-
-using Catch::Matchers::Equals;
 
 #include "../helpers/helpers.ipp"
 

--- a/tests/unit/logic/eject_filament/test_eject_filament.cpp
+++ b/tests/unit/logic/eject_filament/test_eject_filament.cpp
@@ -1,5 +1,4 @@
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_vector.hpp"
 
 #include "../../../../src/modules/buttons.h"
 #include "../../../../src/modules/finda.h"
@@ -17,8 +16,6 @@
 
 #include "../stubs/main_loop_stub.h"
 #include "../stubs/stub_motion.h"
-
-using Catch::Matchers::Equals;
 
 #include "../helpers/helpers.ipp"
 

--- a/tests/unit/logic/failing_tmc/test_failing_tmc.cpp
+++ b/tests/unit/logic/failing_tmc/test_failing_tmc.cpp
@@ -3,7 +3,6 @@
 // Moreover, I didn't want to spoil the unit tests of the state machines themself with this.
 
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_vector.hpp"
 
 #include "../../../../src/modules/buttons.h"
 #include "../../../../src/modules/finda.h"
@@ -22,8 +21,6 @@
 
 #include "../stubs/main_loop_stub.h"
 #include "../stubs/stub_motion.h"
-
-using Catch::Matchers::Equals;
 
 #include "../helpers/helpers.ipp"
 

--- a/tests/unit/logic/feed_to_bondtech/test_feed_to_bondtech.cpp
+++ b/tests/unit/logic/feed_to_bondtech/test_feed_to_bondtech.cpp
@@ -1,5 +1,4 @@
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_vector.hpp"
 
 #include "../../../../src/modules/buttons.h"
 #include "../../../../src/modules/finda.h"
@@ -17,8 +16,6 @@
 
 #include "../stubs/main_loop_stub.h"
 #include "../stubs/stub_motion.h"
-
-using Catch::Matchers::Equals;
 
 namespace ha = hal::adc;
 

--- a/tests/unit/logic/feed_to_finda/test_feed_to_finda.cpp
+++ b/tests/unit/logic/feed_to_finda/test_feed_to_finda.cpp
@@ -1,5 +1,4 @@
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_vector.hpp"
 
 #include "../../../../src/modules/buttons.h"
 #include "../../../../src/modules/finda.h"
@@ -17,8 +16,6 @@
 
 #include "../stubs/main_loop_stub.h"
 #include "../stubs/stub_motion.h"
-
-using Catch::Matchers::Equals;
 
 namespace ha = hal::adc;
 

--- a/tests/unit/logic/homing/test_homing.cpp
+++ b/tests/unit/logic/homing/test_homing.cpp
@@ -1,5 +1,4 @@
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_vector.hpp"
 
 #include "../../../../src/modules/buttons.h"
 #include "../../../../src/modules/finda.h"
@@ -21,8 +20,6 @@
 #include "../stubs/homing.h"
 #include "../stubs/main_loop_stub.h"
 #include "../stubs/stub_motion.h"
-
-using Catch::Matchers::Equals;
 
 #include "../helpers/helpers.ipp"
 

--- a/tests/unit/logic/load_filament/test_load_filament.cpp
+++ b/tests/unit/logic/load_filament/test_load_filament.cpp
@@ -1,6 +1,5 @@
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/generators/catch_generators.hpp"
-#include "catch2/matchers/catch_matchers_vector.hpp"
 
 #include <functional>
 
@@ -23,7 +22,6 @@
 #include "../stubs/main_loop_stub.h"
 #include "../stubs/stub_motion.h"
 
-using Catch::Matchers::Equals;
 using namespace std::placeholders;
 
 #include "../helpers/helpers.ipp"

--- a/tests/unit/logic/tool_change/test_tool_change.cpp
+++ b/tests/unit/logic/tool_change/test_tool_change.cpp
@@ -1,5 +1,4 @@
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_vector.hpp"
 
 #include "../../../../src/modules/buttons.h"
 #include "../../../../src/modules/finda.h"
@@ -23,7 +22,6 @@
 
 #include <functional>
 
-using Catch::Matchers::Equals;
 using namespace std::placeholders;
 
 #include "../helpers/helpers.ipp"

--- a/tests/unit/logic/unload_filament/test_unload_filament.cpp
+++ b/tests/unit/logic/unload_filament/test_unload_filament.cpp
@@ -1,5 +1,4 @@
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_vector.hpp"
 
 #include <functional>
 
@@ -22,7 +21,6 @@
 #include "../stubs/main_loop_stub.h"
 #include "../stubs/stub_motion.h"
 
-using Catch::Matchers::Equals;
 using namespace std::placeholders;
 
 #include "../helpers/helpers.ipp"
@@ -163,7 +161,6 @@ void FindaDidntTriggerCommonSetup(uint8_t slot, logic::UnloadFilament &uf) {
     // green LED should be off
     REQUIRE(VerifyState(uf, mg::FilamentLoadState::InSelector, mi::Idler::IdleSlotIndex(), slot, true, false, ml::off, ml::blink0, ErrorCode::FINDA_DIDNT_SWITCH_OFF, ProgressCode::ERRWaitingForUser));
 }
-
 
 void FindaDidntTriggerResolveTryAgain(uint8_t slot, logic::UnloadFilament &uf) {
     // Stage 3 - the user has to do something

--- a/tests/unit/logic/unload_to_finda/test_unload_to_finda.cpp
+++ b/tests/unit/logic/unload_to_finda/test_unload_to_finda.cpp
@@ -1,6 +1,5 @@
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/generators/catch_generators_range.hpp"
-#include "catch2/matchers/catch_matchers_vector.hpp"
 
 #include <functional>
 
@@ -21,7 +20,6 @@
 #include "../stubs/main_loop_stub.h"
 #include "../stubs/stub_motion.h"
 
-using Catch::Matchers::Equals;
 using namespace std::placeholders;
 
 namespace ha = hal::adc;

--- a/tests/unit/modules/leds/test_leds.cpp
+++ b/tests/unit/modules/leds/test_leds.cpp
@@ -1,12 +1,9 @@
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/generators/catch_generators.hpp"
-#include "catch2/matchers/catch_matchers_vector.hpp"
 #include "leds.h"
 #include "shr16.h"
 #include "../stubs/stub_timebase.h"
 #include "../../../../src/modules/timebase.h"
-
-using Catch::Matchers::Equals;
 
 uint16_t millis = 0;
 

--- a/tests/unit/modules/pulse_gen/test_pulse_gen.cpp
+++ b/tests/unit/modules/pulse_gen/test_pulse_gen.cpp
@@ -1,10 +1,8 @@
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_vector.hpp"
 #include "pulse_gen.h"
 #include "../pins.h"
 #include <stdio.h>
 
-using Catch::Matchers::Equals;
 using namespace modules::pulse_gen;
 using hal::gpio::Level;
 using hal::gpio::ReadPin;

--- a/tests/unit/modules/speed_table/test_speed_table.cpp
+++ b/tests/unit/modules/speed_table/test_speed_table.cpp
@@ -1,9 +1,7 @@
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_vector.hpp"
 #include "speed_table.h"
 #include <stdio.h>
 
-using Catch::Matchers::Equals;
 using namespace modules::speed_table;
 
 // The following reference values are calculated for 2MHz timer

--- a/tests/unit/modules/timebase/test_timebase.cpp
+++ b/tests/unit/modules/timebase/test_timebase.cpp
@@ -1,9 +1,6 @@
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_vector.hpp"
 #include "timebase.h"
 #include "../stubs/stub_timebase.h"
-
-using Catch::Matchers::Equals;
 
 // this is not a pure test of the real implementation (it would require splitting the timebase.cpp into 2 parts)
 // but serves the sole purpose of debugging the Elapsed() impl.


### PR DESCRIPTION
Not critical, just wanted to remove the unnecessary include since it's not doing anything useful for us.