### PR TITLE
Optimise CircularIndex count() method

### DIFF
--- a/src/hal/circular_buffer.h
+++ b/src/hal/circular_buffer.h
@@ -61,15 +61,8 @@ public:
     }
 
     /// @returns number of elements in the buffer
-    /// @@TODO better solution if it exists
     inline index_t count() const {
-        index_t i = tail;
-        index_t c = 0;
-        while (i != head) {
-            i = next(i);
-            ++c;
-        }
-        return c;
+        return head - tail;
     }
 
 protected:


### PR DESCRIPTION
Since head and tail are unsigned, with same bit width and always a power of 2, `head - tail` is always valid.

For example, head = 2, tail = 254 will yield `2 - 254 = 4`

Sadly there is no change in memory
