### PR TITLE
catch2: Fix build with gcc13

### DIFF
--- a/lib/Catch2/src/catch2/catch_test_case_info.hpp
+++ b/lib/Catch2/src/catch2/catch_test_case_info.hpp
@@ -15,6 +15,7 @@
 #include <catch2/internal/catch_unique_ptr.hpp>
 
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/lib/Catch2/src/catch2/internal/catch_string_manip.hpp
+++ b/lib/Catch2/src/catch2/internal/catch_string_manip.hpp
@@ -10,6 +10,7 @@
 
 #include <catch2/internal/catch_stringref.hpp>
 
+#include <cstdint>
 #include <string>
 #include <iosfwd>
 #include <vector>

--- a/lib/Catch2/src/catch2/internal/catch_xmlwriter.cpp
+++ b/lib/Catch2/src/catch2/internal/catch_xmlwriter.cpp
@@ -11,6 +11,7 @@
 #include <catch2/internal/catch_enforce.hpp>
 #include <catch2/internal/catch_xmlwriter.hpp>
 
+#include <cstdint>
 #include <iomanip>
 #include <type_traits>
 


### PR DESCRIPTION
Cherrypick of catch2 commit 52066dbc2a53f4c3ab2a418d03f93200a8245451 to fix the build with gcc 13 without a full update just before release.