### PR TITLE
Move MMU registers into PROGMEM

### DIFF
--- a/src/hal/progmem.h
+++ b/src/hal/progmem.h
@@ -31,5 +31,18 @@ static inline uint8_t read_byte(const uint8_t *addr) {
 #endif
 }
 
+/// read a ptr from PROGMEM
+/// Introduced mainly for compatibility reasons with the unit tests
+/// and to hide the ugly reinterpret_casts.
+/// Returns a correctly typed pointer: a 16-bit on AVR, but a 64bit address on x86_64
+template <typename RT>
+static inline RT read_ptr(const void *addr) {
+#ifndef __AVR__
+    return reinterpret_cast<RT>(*reinterpret_cast<const uint64_t *>(addr));
+#else
+    return reinterpret_cast<RT>(pgm_read_ptr(addr));
+#endif
+}
+
 } // namespace progmem
 } // namespace hal


### PR DESCRIPTION
🚧 This is not tested! But this is what I have so far. Please don't merge yet.

Change in memory:
Flash: +34 bytes
SRAM: -170 bytes

with [2da6f6c](https://github.com/prusa3d/Prusa-Firmware-MMU-Private/pull/287/commits/2da6f6c714afccdc5f2542ed41c9a9e587a1abb5) the code size actually shrunk by 8B (as originally expected)

Latest refactoring made the code size shrink by 44B

MMU-253