### PR TITLE
cmake: Set source epoch from the HEAD commit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,10 @@ set(BUILD_NUMBER
     ""
     CACHE STRING "Build number of the firmware. Resolved automatically if not specified."
     )
+set(PROJECT_VERSION_TIMESTAMP
+    ""
+    CACHE STRING "Timestamp for the build. Resolved automatically if not specified."
+    )
 set(CUSTOM_COMPILE_OPTIONS
     ""
     CACHE STRING "Allows adding custom C/C++ flags"
@@ -96,8 +100,8 @@ add_compile_options(-g)
 
 # optimizations
 if(CMAKE_CROSSCOMPILING)
-  # TODO: get date from the last git commit to set as epoch
-  set_source_epoch(0)
+  # set source epoch
+  set_source_epoch(${PROJECT_VERSION_TIMESTAMP})
 
   # default optimization flags
   set(CMAKE_CXX_FLAGS_DEBUG "-Og -g")

--- a/cmake/GetGitRevisionDescription.cmake
+++ b/cmake/GetGitRevisionDescription.cmake
@@ -29,6 +29,10 @@
 # I don't know if get_git_head_revision() must be called internally or not, as reason of calling it
 # is not clear for me also in git_local_changes().
 #
+# git_head_commit_timestamp(<var>)
+#
+# Returns the timestamp of the HEAD commit.
+#
 # Requires CMake 2.6 or newer (uses the 'function' command)
 #
 # Original Author: 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
@@ -229,4 +233,52 @@ function(git_count_parent_commits _var)
         )
   endif()
 
+endfunction()
+
+function(git_get_commit_timestamp _var hash)
+  execute_process(
+    COMMAND "${GIT_EXECUTABLE}" show -s "--format=%ct" "${hash}"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    RESULT_VARIABLE res
+    OUTPUT_VARIABLE out
+    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  if(res EQUAL 0)
+    set(${_var}
+        "${out}"
+        PARENT_SCOPE
+        )
+  else()
+    set(${_var}
+        "0"
+        PARENT_SCOPE
+        )
+  endif()
+
+endfunction()
+
+function(git_head_commit_timestamp _var)
+  if(NOT GIT_FOUND)
+    find_package(Git QUIET)
+  endif()
+  get_git_head_revision(refspec hash)
+  if(NOT GIT_FOUND)
+    set(${_var}
+        "GIT-NOTFOUND"
+        PARENT_SCOPE
+        )
+    return()
+  endif()
+  if(NOT hash)
+    set(${_var}
+        "HEAD-HASH-NOTFOUND"
+        PARENT_SCOPE
+        )
+    return()
+  endif()
+  git_get_commit_timestamp(timestamp ${hash})
+  set(${_var}
+      "${timestamp}"
+      PARENT_SCOPE
+      )
 endfunction()

--- a/cmake/ProjectVersion.cmake
+++ b/cmake/ProjectVersion.cmake
@@ -7,6 +7,7 @@
 # PROJECT_VERSION_FULL (4.0.3-BETA+1035.PR111.B4)
 # PROJECT_VERSION_SUFFIX (-BETA+1035.PR111.B4)
 # PROJECT_VERSION_SUFFIX_SHORT (+1035)
+# PROJECT_VERSION_TIMESTAMP (unix timestamp)
 #
 # The `PROJECT_VERSION` variable is set as soon as the file is included.
 # To set the rest, the function `resolve_version_variables` has to be called.
@@ -55,4 +56,14 @@ function(resolve_version_variables)
       "${PROJECT_VERSION}${PROJECT_VERSION_SUFFIX}"
       PARENT_SCOPE
       )
+
+  # PROJECT_VERSION_TIMESTAMP
+  if(NOT PROJECT_VERSION_TIMESTAMP)
+    git_head_commit_timestamp(timestamp)
+    set(PROJECT_VERSION_TIMESTAMP
+        "${timestamp}"
+        PARENT_SCOPE
+        )
+  endif()
+
 endfunction()


### PR DESCRIPTION
Allow to set the source epoch of the build with
PROJECT_VERSION_TIMESTAMP.

When unset fetch the commit timestamp of the current HEAD automatically instead of leaving the source as 0.

We have no use for this on the MMU, but it doesn't hurt to follow what we do on the MK3.