### PR TITLE
PFW-1480 Process the Mode command

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -255,6 +255,7 @@ void Application::ProcessRequestMsg(const mp::RequestMsg &rq) {
     case mp::RequestMsgCodes::Eject:
     case mp::RequestMsgCodes::Home:
     case mp::RequestMsgCodes::Load:
+    case mp::RequestMsgCodes::Mode:
     case mp::RequestMsgCodes::Tool:
     case mp::RequestMsgCodes::Unload:
         PlanCommand(rq);


### PR DESCRIPTION
This allows the printer to change the TMC2130 modes via the protocol interface.

⚠️ We may remove the Silent and Normal modes from the firmware, but it needs to be tested first and discussed. Same on the printer side.

* Respective 8-bit FW PR: https://github.com/prusa3d/Prusa-Firmware/pull/4278

No change in memory