### PR TITLE
BFW-3317: New filenames for hex files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,8 +183,10 @@ if(CMAKE_CROSSCOMPILING)
     COMMAND ${CMAKE_OBJCOPY} firmware -O binary --gap-fill 0xFF --pad-to 0x00007000 firmware.bin
     COMMAND ${CMAKE_COMMAND} -E cat firmware.bin bootloader.bin > fw_bootloader.bin
     COMMAND ${CMAKE_OBJCOPY} -I binary -O ihex fw_bootloader.bin
-            "MMU3_${PROJECT_VERSION}${PROJECT_VERSION_SUFFIX_SHORT}_bootloader.hex"
-    BYPRODUCTS bootloader.bin firmware.bin fw_bootloader.bin
+            "MMU2S_MMU3_BOOTLOADER_${PROJECT_VERSION}${PROJECT_VERSION_SUFFIX_SHORT}.hex"
+    COMMAND
+      ${CMAKE_COMMAND} -E copy "MMU2S_MMU3_BOOTLOADER_${PROJECT_VERSION}${PROJECT_VERSION_SUFFIX_SHORT}.hex" "MMU2S_MMU3_BOOTLOADER_${PROJECT_VERSION}.hex"
+          BYPRODUCTS bootloader.bin firmware.bin fw_bootloader.bin
     )
 
   # produce ASM listing
@@ -212,8 +214,10 @@ if(CMAKE_CROSSCOMPILING)
     POST_BUILD
     COMMAND
       ${CMAKE_COMMAND} -D WORK_DIR=${CMAKE_BINARY_DIR} -D
-      HEX_NAME="MMU3_${PROJECT_VERSION}${PROJECT_VERSION_SUFFIX_SHORT}.hex" -P
+      HEX_NAME="MMU2S_MMU3_FW${PROJECT_VERSION}${PROJECT_VERSION_SUFFIX_SHORT}.hex" -P
       ${CMAKE_SOURCE_DIR}/cmake/HexConcat.cmake DEPENDS firmware.hex
+    COMMAND
+      ${CMAKE_COMMAND} -E copy "MMU2S_MMU3_FW${PROJECT_VERSION}${PROJECT_VERSION_SUFFIX_SHORT}.hex" "MMU2S_MMU3_FW${PROJECT_VERSION}.hex"
     )
 
 endif()


### PR DESCRIPTION
Following new naming convention.

Two copies one with build number for testing one without for releases.