### PR TITLE
Update PR size to show

### DIFF
--- a/.github/workflows/pr-size.sh
+++ b/.github/workflows/pr-size.sh
@@ -10,7 +10,7 @@ test -x "$AVR_SIZE" || exit 2
 
 avr_size()
 {
-    "$AVR_SIZE" --mcu=atmega2560 -C "$@"
+    "$AVR_SIZE" --mcu=atmel32u4 -C "$@"
 }
 
 avr_flash()
@@ -24,9 +24,14 @@ avr_ram()
 }
 
 cat <<EOF > "$MESSAGE"
-| ΔFlash (bytes) | ΔSRAM (bytes) |
-| -------------- | ------------- |
+All values in bytes. Δ Delta to base
+
+| ΔFlash | ΔSRAM | Used Flash | Used SRAM | Free Flash | Free SRAM |
+| ------ | ----- | -----------| --------- | ---------- | --------- |
 EOF
+
+atmel32u4_max_upload_size=$(grep "prusa_mm_control.upload.maximum_size=" .dependencies/prusa3dboards-*/boards.txt | cut -d "=" -f2)
+atmel32u4_max_upload_data_size=$(grep "prusa_mm_control.upload.maximum_data_size=" .dependencies/prusa3dboards-*/boards.txt | cut -d "=" -f2)
 
 base_bin=$(echo ${BASE_DIR}/firmware)
 base_flash=$(avr_flash "$base_bin")
@@ -39,4 +44,7 @@ pr_ram=$(avr_ram "$pr_bin")
 flash_d=$(($pr_flash - $base_flash))
 ram_d=$(($pr_ram - $base_ram))
 
-echo "| $flash_d | $ram_d |" >> "$MESSAGE"
+flash_free=$(($atmel32u4_max_upload_size - $pr_flash))
+ram_free=$(($atmel32u4_max_upload_data_size - $pr_ram))
+
+echo "| $flash_d | $ram_d | $pr_flash | $pr_ram | $flash_free | $ram_free |" >> "$MESSAGE"


### PR DESCRIPTION
- Delta
- Used
- Free
Flash/SRAM bytes

## Automated Test Code Coverage Report

<details><summary>View details... </summary>
<p>

File | Lines | Exec | Cover   
-----|---------|--------|--------
src/application.cpp | 169 | 14 | 8%
src/application.h | 3 | 3 | 100%
src/hal/circular_buffer.h | 52 | 52 | 100%
src/hal/eeprom.h | 1 | 0 | 0%
src/hal/gpio.h | 18 | 7 | 38%
src/hal/progmem.h | 6 | 6 | 100%
src/hal/tmc2130.cpp | 113 | 9 | 7%
src/hal/tmc2130.h | 31 | 27 | 87%
src/logic/command_base.cpp | 139 | 118 | 84%
src/logic/command_base.h | 4 | 3 | 75%
src/logic/cut_filament.cpp | 117 | 80 | 68%
src/logic/eject_filament.cpp | 77 | 60 | 77%
src/logic/feed_to_bondtech.cpp | 60 | 57 | 95%
src/logic/feed_to_bondtech.h | 1 | 1 | 100%
src/logic/feed_to_finda.cpp | 48 | 45 | 93%
src/logic/feed_to_finda.h | 1 | 1 | 100%
src/logic/home.cpp | 18 | 12 | 66%
src/logic/load_filament.cpp | 85 | 77 | 90%
src/logic/load_filament.h | 1 | 0 | 0%
src/logic/move_selector.cpp | 21 | 0 | 0%
src/logic/no_command.h | 2 | 1 | 50%
src/logic/retract_from_finda.cpp | 27 | 21 | 77%
src/logic/retract_from_finda.h | 1 | 1 | 100%
src/logic/set_mode.cpp | 5 | 0 | 0%
src/logic/set_mode.h | 1 | 0 | 0%
src/logic/start_up.cpp | 38 | 26 | 68%
src/logic/start_up.h | 4 | 4 | 100%
src/logic/tool_change.cpp | 108 | 82 | 75%
src/logic/unload_filament.cpp | 76 | 69 | 90%
src/logic/unload_to_finda.cpp | 40 | 39 | 97%
src/logic/unload_to_finda.h | 1 | 1 | 100%
src/modules/axisunit.h | 21 | 21 | 100%
src/modules/buttons.cpp | 11 | 11 | 100%
src/modules/buttons.h | 7 | 7 | 100%
src/modules/crc.h | 13 | 13 | 100%
src/modules/debouncer.cpp | 28 | 24 | 85%
src/modules/debouncer.h | 7 | 7 | 100%
src/modules/finda.cpp | 7 | 3 | 42%
src/modules/finda.h | 2 | 2 | 100%
src/modules/fsensor.cpp | 6 | 6 | 100%
src/modules/fsensor.h | 3 | 3 | 100%
src/modules/globals.cpp | 46 | 41 | 89%
src/modules/globals.h | 31 | 22 | 70%
src/modules/idler.cpp | 89 | 82 | 92%
src/modules/idler.h | 12 | 12 | 100%
src/modules/leds.cpp | 44 | 42 | 95%
src/modules/leds.h | 16 | 15 | 93%
src/modules/math.h | 6 | 6 | 100%
src/modules/motion.cpp | 59 | 40 | 67%
src/modules/motion.h | 66 | 64 | 96%
src/modules/movable_base.cpp | 73 | 70 | 95%
src/modules/movable_base.h | 16 | 16 | 100%
src/modules/permanent_storage.cpp | 144 | 89 | 61%
src/modules/protocol.cpp | 216 | 184 | 85%
src/modules/protocol.h | 72 | 70 | 97%
src/modules/pulley.cpp | 33 | 25 | 75%
src/modules/pulley.h | 8 | 5 | 62%
src/modules/pulse_gen.cpp | 95 | 89 | 93%
src/modules/pulse_gen.h | 53 | 51 | 96%
src/modules/selector.cpp | 69 | 62 | 89%
src/modules/selector.h | 5 | 5 | 100%
src/modules/speed_table.h | 26 | 24 | 92%
src/modules/user_input.cpp | 39 | 39 | 100%
src/modules/user_input.h | 12 | 12 | 100%
src/modules/voltage.cpp | 4 | 0 | 0%
src/registers.cpp | 102 | 37 | 36%
src/unit.h | 12 | 12 | 100%
**TOTAL** | **2721** | **2027** | **74%**

</details>

**TOTAL: 2721 lines of code, 2027 lines executed, 74% covered.**
