### PR TITLE
Upgrade ninja from 1.10.2 to 1.12.1

### DIFF
--- a/.vscode/cmake-kits.json
+++ b/.vscode/cmake-kits.json
@@ -3,7 +3,7 @@
         "name": "avr-gcc",
         "toolchainFile": "${workspaceFolder}/cmake/AvrGcc.cmake",
         "cmakeSettings": {
-            "CMAKE_MAKE_PROGRAM": "${workspaceFolder}/.dependencies/ninja-1.10.2/ninja",
+            "CMAKE_MAKE_PROGRAM": "${workspaceFolder}/.dependencies/ninja-1.12.1/ninja",
             "CMAKE_BUILD_TYPE": "Release"
         }
     }

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Run `./utils/bootstrap.py`
 `bootstrap.py` will now download all the "missing" dependencies into the `.dependencies` folder:
 - clang-format-9.0.0-noext
 - cmake-3.22.5
-- ninja-1.10.2
+- ninja-1.12.1
 - avr-gcc-7.3.0
 
 ### How to build the preliminary project so far:

--- a/utils/bootstrap.py
+++ b/utils/bootstrap.py
@@ -19,6 +19,7 @@ import tarfile
 import zipfile
 from argparse import ArgumentParser
 from pathlib import Path
+from tarfile import TarFile
 from urllib.request import urlretrieve
 project_root_dir = Path(__file__).resolve().parent.parent
 dependencies_dir = project_root_dir / '.dependencies'
@@ -99,7 +100,11 @@ def download_and_unzip(url: str, directory: Path):
         obj = tarfile.open(f)
     else:
         obj = zipfile.ZipFile(f, 'r')
-    obj.extractall(path=str(extract_dir))
+
+    if isinstance(obj, TarFile):
+        obj.extractall(path=str(extract_dir), filter='data')
+    else: # Zip file
+        obj.extractall(path=str(extract_dir))
 
     subdir = find_single_subdir(extract_dir)
     shutil.move(str(subdir), str(directory))

--- a/utils/bootstrap.py
+++ b/utils/bootstrap.py
@@ -29,11 +29,11 @@ dependencies_dir = project_root_dir / '.dependencies'
 # yapf: disable
 dependencies = {
     'ninja': {
-        'version': '1.10.2',
+        'version': '1.12.1',
         'url': {
-            'Linux': 'https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip',
-            'Windows': 'https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip',
-            'Darwin': 'https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-mac.zip',
+            'Linux': 'https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip',
+            'Windows': 'https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip',
+            'Darwin': 'https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-mac.zip',
         },
     },
     'cmake': {

--- a/utils/holly/Jenkinsfile
+++ b/utils/holly/Jenkinsfile
@@ -93,11 +93,11 @@ pipeline {
             steps {
                 sh """
                 python3 utils/bootstrap.py
-                export PATH=\$PWD/.dependencies/cmake-3.22.5/bin:\$PWD/.dependencies/ninja-1.10.2:\$PATH
+                export PATH=\$PWD/.dependencies/cmake-3.22.5/bin:\$PWD/.dependencies/ninja-1.12.1:\$PATH
                 export CTEST_OUTPUT_ON_FAILURE=1
                 mkdir -p build-test
                 LD_LIBRARY_PATH=/usr/local/lib32 \$PWD/.dependencies/cmake-3.22.5/bin/ctest --build-and-test . build-test \
-                    -DCMAKE_MAKE_PROGRAM=\$PWD/.dependencies/ninja-1.10.2/ninja \
+                    -DCMAKE_MAKE_PROGRAM=\$PWD/.dependencies/ninja-1.12.1/ninja \
                     --build-generator Ninja \
                     --build-target tests \
                     --test-command ctest


### PR DESCRIPTION
I'm proposing to update Ninja in the Prusa-Firmware repo. This PR is simply a proposal to keep the MMU project in sync as well.

The update brings better support for Windows :) This doesn't fix any reported issues on our side, but I don't see any harm in keeping up with the latest changes and improvements.

Some highlights:

* Ninja uses UTF-8 now on Windows (previous versions used local ANSI encoding)
* Support for path lengths over 260 characters on Windows

Additionally fixed one `DeprecationWarning` raised by Python 3.12.4 when running `bootstrap.py`.

Changelogs:

* https://github.com/ninja-build/ninja/releases/tag/v1.12.1
* https://github.com/ninja-build/ninja/releases/tag/v1.12.0
* https://github.com/ninja-build/ninja/releases/tag/v1.11.1
* https://github.com/ninja-build/ninja/releases/tag/v1.11.0