### PR TITLE
optimisation: set `enum` types explictly to `uint8_t`

### DIFF
--- a/src/logic/feed_to_bondtech.h
+++ b/src/logic/feed_to_bondtech.h
@@ -17,7 +17,7 @@ namespace logic {
 /// To prevent constant EEPROM updates only significant changes are recorded.
 struct FeedToBondtech {
     /// internal states of the state machine
-    enum {
+    enum : uint8_t {
         EngagingIdler,
         PushingFilamentFast,
         PushingFilamentToFSensor,

--- a/src/logic/feed_to_finda.h
+++ b/src/logic/feed_to_finda.h
@@ -12,7 +12,7 @@ namespace logic {
 /// Leaves the Pulley axis enabled for chaining potential next operations
 struct FeedToFinda {
     /// internal states of the state machine
-    enum {
+    enum : uint8_t {
         EngagingIdler,
         PushingFilament,
         PushingFilamentUnlimited,

--- a/src/logic/hw_sanity.cpp
+++ b/src/logic/hw_sanity.cpp
@@ -32,7 +32,7 @@ bool HWSanity::Reset(uint8_t param) {
     return true;
 }
 
-enum pin_bits {
+enum pin_bits : uint8_t {
     BIT_STEP = 0b001,
     BIT_DIR = 0b010,
     BIT_ENA = 0b100,

--- a/src/logic/result_codes.h
+++ b/src/logic/result_codes.h
@@ -7,7 +7,7 @@
 /// therefore the error codes have been extracted to one place.
 ///
 /// Please note that currently only LoadFilament can return something else than "OK"
-enum class ResultCode : uint_fast16_t {
+enum class ResultCode : uint_fast8_t {
     OK = 0,
     Cancelled = 1
 };

--- a/src/logic/retract_from_finda.h
+++ b/src/logic/retract_from_finda.h
@@ -13,7 +13,7 @@ namespace logic {
 /// - leaves idler engaged for chaining operations
 struct RetractFromFinda {
     /// internal states of the state machine
-    enum {
+    enum : uint8_t {
         EngagingIdler,
         UnloadBackToPTFE,
         OK,

--- a/src/logic/unload_to_finda.h
+++ b/src/logic/unload_to_finda.h
@@ -13,7 +13,7 @@ namespace logic {
 /// - load/unload to finda
 struct UnloadToFinda {
     /// internal states of the state machine
-    enum {
+    enum : uint8_t {
         EngagingIdler,
         UnloadingToFinda,
         WaitingForFINDA,

--- a/src/modules/buttons.h
+++ b/src/modules/buttons.h
@@ -20,7 +20,7 @@ private:
 };
 
 /// Enum of buttons - used also as indices in an array of buttons to keep the code size tight.
-enum {
+enum : uint8_t {
     Right = 0,
     Middle,
     Left

--- a/src/modules/debouncer.h
+++ b/src/modules/debouncer.h
@@ -28,7 +28,7 @@ private:
     /// Intentionally not modeled as an enum class
     /// as it would impose additional casts which do not play well with the struct Flags
     /// and would make the code less readable
-    enum State {
+    enum State : uint8_t {
         Waiting = 0,
         Detected,
         WaitForRelease,

--- a/src/modules/leds.h
+++ b/src/modules/leds.h
@@ -20,7 +20,7 @@ namespace leds {
 
 /// Enum of LED modes
 /// blink0 and blink1 allow for interlaced blinking of LEDs (one is on and the other off)
-enum Mode {
+enum Mode : uint8_t {
     off,
     on,
     blink0, ///< start blinking at even periods
@@ -28,7 +28,7 @@ enum Mode {
 };
 
 /// Enum of LEDs color - green or red
-enum Color {
+enum Color : uint8_t {
     red = 0,
     green = 1
 };

--- a/src/modules/movable_base.h
+++ b/src/modules/movable_base.h
@@ -11,7 +11,7 @@ namespace motion {
 class MovableBase {
 public:
     /// Internal states of the state machine
-    enum {
+    enum : uint8_t {
         Ready = 0, // intentionally set as zero in order to allow zeroing the Idler structure upon startup -> avoid explicit initialization code
         Moving = 1,
         PlannedHome = 2,

--- a/src/modules/permanent_storage.h
+++ b/src/modules/permanent_storage.h
@@ -68,7 +68,7 @@ public:
     static bool set(uint8_t filament);
 
 private:
-    enum Key {
+    enum Key : uint8_t {
         KeyFront1,
         KeyReverse1,
         KeyFront2,


### PR DESCRIPTION
This commit produces the same savings as the compiler option `-fshort-enums`. Except by setting the types manually we save also 2 bytes of SRAM.

By default, the `enum` type is 2 bytes, we can explicitly set it to one byte when applicable to reduce code size.

Almost all the savings come from `enum Mode` in leds.h.

Change in memory:
Flash: -116 bytes
SRAM: -2 bytes