### PR TITLE
optimisation: compare `uint16_t` against `uint16_t` in `FinishHomingAndPlanMoveToParkPos`

### DIFF
--- a/src/modules/idler.cpp
+++ b/src/modules/idler.cpp
@@ -39,7 +39,7 @@ void Idler::PlanHomingMoveBack() {
 bool Idler::FinishHomingAndPlanMoveToParkPos() {
     // check the axis' length
     if (AxisDistance(mm::axisUnitToTruncatedUnit<config::U_deg>(mm::motion.CurPosition<mm::Idler>()))
-        < (config::idlerLimits.lenght.v - 10)) { //@@TODO is 10 degrees ok?
+        < uint16_t(config::idlerLimits.lenght.v - 10)) { //@@TODO is 10 degrees ok?
         return false; // we couldn't home correctly, we cannot set the Idler's position
     }
 

--- a/src/modules/selector.cpp
+++ b/src/modules/selector.cpp
@@ -35,7 +35,7 @@ void Selector::PlanHomingMoveBack() {
 
 bool Selector::FinishHomingAndPlanMoveToParkPos() {
     // check the axis' length
-    if (AxisDistance(mm::axisUnitToTruncatedUnit<config::U_mm>(mm::motion.CurPosition<mm::Selector>())) < (config::selectorLimits.lenght.v - 3)) { //@@TODO is 3mm ok?
+    if (AxisDistance(mm::axisUnitToTruncatedUnit<config::U_mm>(mm::motion.CurPosition<mm::Selector>())) < uint16_t(config::selectorLimits.lenght.v - 3)) { //@@TODO is 3mm ok?
         return false; // we couldn't home correctly, we cannot set the Selector's position
     }
 


### PR DESCRIPTION
`AxisDistance` returns `uint16_t` type and is currently compared with `long double` axis length. The axis lengths fit easily into `uint16_t`:

```
selectorLimits.lenght = 75.0
idlerLimits.lenght = 225.0
```

Change in memory:
Flash: -122 bytes
SRAM: 0 bytes

----

Below is the changes to the assembly output for the selector limits. This optimisation removes a call to `__floatunsisf` and `__cmpsf2`

Before

```asm
if (AxisDistance(mm::axisUnitToTruncatedUnit<config::U_mm>(mm::motion.CurPosition<mm::Selector>())) < (config::selectorLimits.lenght.v - 3)) { //@@TODO is 3mm ok?
    2174:	ce 01       	movw	r24, r28
    2176:	0e 94 79 07 	call	0xef2	; 0xef2 <modules::motion::MovableBase::AxisDistance(long) const>
    217a:	bc 01       	movw	r22, r24
    217c:	90 e0       	ldi	r25, 0x00	; 0
    217e:	80 e0       	ldi	r24, 0x00	; 0
    2180:	0e 94 93 34 	call	0x6926	; 0x6926 <__floatunsisf>
    2184:	20 e0       	ldi	r18, 0x00	; 0
    2186:	30 e0       	ldi	r19, 0x00	; 0
    2188:	40 e9       	ldi	r20, 0x90	; 144
    218a:	52 e4       	ldi	r21, 0x42	; 66
    218c:	0e 94 58 34 	call	0x68b0	; 0x68b0 <__cmpsf2>
    2190:	87 fd       	sbrc	r24, 7
    2192:	1a c0       	rjmp	.+52     	; 0x21c8 <modules::selector::Selector::FinishHomingAndPlanMoveToParkPos()+0x70>
    2194:	88 e9       	ldi	r24, 0x98	; 152
    2196:	9a e3       	ldi	r25, 0x3A	; 58
    2198:	a0 e0       	ldi	r26, 0x00	; 0
    219a:	b0 e0       	ldi	r27, 0x00	; 0
    219c:	80 93 8b 05 	sts	0x058B, r24	; 0x80058b <modules::motion::motion+0x142>
    21a0:	90 93 8c 05 	sts	0x058C, r25	; 0x80058c <modules::motion::motion+0x143>
    21a4:	a0 93 8d 05 	sts	0x058D, r26	; 0x80058d <modules::motion::motion+0x144>
    21a8:	b0 93 8e 05 	sts	0x058E, r27	; 0x80058e <modules::motion::motion+0x145>
```

After:

```asm
if (AxisDistance(mm::axisUnitToTruncatedUnit<config::U_mm>(mm::motion.CurPosition<mm::Selector>())) < uint16_t(config::selectorLimits.lenght.v - 3)) { //@@TODO is 3mm ok?
    2174:	ce 01       	movw	r24, r28
    2176:	0e 94 79 07 	call	0xef2	; 0xef2 <modules::motion::MovableBase::AxisDistance(long) const>
    217a:	88 34       	cpi	r24, 0x48	; 72
    217c:	91 05       	cpc	r25, r1
    217e:	d0 f0       	brcs	.+52     	; 0x21b4 <modules::selector::Selector::FinishHomingAndPlanMoveToParkPos()+0x5c>
    2180:	88 e9       	ldi	r24, 0x98	; 152
    2182:	9a e3       	ldi	r25, 0x3A	; 58
    2184:	a0 e0       	ldi	r26, 0x00	; 0
    2186:	b0 e0       	ldi	r27, 0x00	; 0
    2188:	80 93 8b 05 	sts	0x058B, r24	; 0x80058b <modules::motion::motion+0x142>
    218c:	90 93 8c 05 	sts	0x058C, r25	; 0x80058c <modules::motion::motion+0x143>
    2190:	a0 93 8d 05 	sts	0x058D, r26	; 0x80058d <modules::motion::motion+0x144>
    2194:	b0 93 8e 05 	sts	0x058E, r27	; 0x80058e <modules::motion::motion+0x145>
```