### PR TITLE
optimisation: calculate steps per unit reciprocal at compile time

### DIFF
--- a/src/config/axis.h
+++ b/src/config/axis.h
@@ -28,6 +28,7 @@ struct AxisConfig {
     uint8_t iHold; ///< holding current
     bool stealth; ///< Default to Stealth mode
     long double stepsPerUnit; ///< steps per unit
+    long double stepsPerUnitReciprocal; ///< reciprocal of step per unit (used to avoid divisions)
     int8_t sg_thrs; /// @todo 7bit two's complement for the sg_thrs
 };
 

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -115,6 +115,7 @@ static constexpr AxisConfig pulley = {
     .iHold = 0, /// 17mA in SpreadCycle, freewheel in StealthChop
     .stealth = false,
     .stepsPerUnit = (200 * 8 / 19.147274),
+    .stepsPerUnitReciprocal = 1 / ((200 * 8 / 19.147274)),
     .sg_thrs = 8,
 };
 
@@ -140,6 +141,7 @@ static constexpr AxisConfig selector = {
     .iHold = 0, /// 17mA in SpreadCycle, freewheel in StealthChop
     .stealth = false,
     .stepsPerUnit = (200 * 8 / 8.),
+    .stepsPerUnitReciprocal = 1 / ((200 * 8 / 8.)),
     .sg_thrs = 3,
 };
 
@@ -190,6 +192,7 @@ static constexpr AxisConfig idler = {
     .iHold = 5, /// 99mA - parked current
     .stealth = false,
     .stepsPerUnit = (200 * 16 / 360.),
+    .stepsPerUnitReciprocal = 1 / ((200 * 16 / 360.)),
     .sg_thrs = 7,
 };
 

--- a/src/modules/axisunit.h
+++ b/src/modules/axisunit.h
@@ -94,12 +94,13 @@ constexpr AxisUnit<T, A, U> operator*(const long double f, const AxisUnit<T, A, 
 struct AxisScale {
     unit::UnitBase base;
     long double stepsPerUnit;
+    long double stepsPerUnitReciprocal;
 };
 
 static constexpr AxisScale axisScale[config::NUM_AXIS] = {
-    { config::pulleyLimits.base, config::pulley.stepsPerUnit },
-    { config::selectorLimits.base, config::selector.stepsPerUnit },
-    { config::idlerLimits.base, config::idler.stepsPerUnit },
+    { config::pulleyLimits.base, config::pulley.stepsPerUnit, config::pulley.stepsPerUnitReciprocal },
+    { config::selectorLimits.base, config::selector.stepsPerUnit, config::selector.stepsPerUnitReciprocal },
+    { config::idlerLimits.base, config::idler.stepsPerUnit, config::idler.stepsPerUnitReciprocal },
 };
 
 /// Convert a unit::Unit to AxisUnit.
@@ -126,7 +127,7 @@ template <typename U, typename AU, typename T = int32_t>
 static constexpr T axisUnitToTruncatedUnit(AU v, long double mul = 1.) {
     static_assert(AU::unit == U::unit, "incorrect unit type conversion");
     static_assert(U::base == axisScale[AU::axis].base, "incorrect unit base conversion");
-    return { ((T)v.v / (T)(axisScale[AU::axis].stepsPerUnit / mul)) };
+    return { ((T)v.v * (T)(axisScale[AU::axis].stepsPerUnitReciprocal * mul)) };
 }
 
 /// Truncate an Unit type to an integer (normally int32_t)


### PR DESCRIPTION
Using the reciprocal allows us to use multiplication instead of division at runtime.

This commit removes 7 divison operations at run time.

Change in memory:
Flash: -210 bytes
SRAM: 0 bytes