### PR TITLE
tests: fix `-Wparentheses` warning in Github CI

### DIFF
--- a/tests/unit/logic/stubs/main_loop_stub.cpp
+++ b/tests/unit/logic/stubs/main_loop_stub.cpp
@@ -181,10 +181,10 @@ void SimulateErrDisengagingIdler(logic::CommandBase &cb, ErrorCode deferredEC) {
     REQUIRE(WhileCondition(
         cb, [&](uint32_t) {
             if (cb.TopLevelState() == ProgressCode::ERRDisengagingIdler) {
-                REQUIRE(cb.Error() == ErrorCode::RUNNING); // ensure the error gets never set while disengaging the idler
+                REQUIRE((cb.Error() == ErrorCode::RUNNING)); // ensure the error gets never set while disengaging the idler
                 return true;
             } else {
-                REQUIRE(cb.Error() == deferredEC);
+                REQUIRE((cb.Error() == deferredEC));
                 return false;
             }
         },


### PR DESCRIPTION
`warning: suggest parentheses around comparison in operand of ‘==’ [-Wparentheses]`

The following error is appearing in all pull requests:
```

 [253/708] Building CXX object tests/unit/logic/feed_to_finda/CMakeFiles/feed_to_finda_tests.dir/__/stubs/main_loop_stub.o
In file included from /home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/lib/Catch2/src/catch2/../catch2/catch_tostring.hpp:17,
                 from /home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/lib/Catch2/src/catch2/../catch2/internal/catch_decomposer.hpp:11,
                 from /home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/lib/Catch2/src/catch2/../catch2/internal/catch_assertion_handler.hpp:12,
                 from /home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/lib/Catch2/src/catch2/../catch2/internal/catch_test_macro_impl.hpp:12,
                 from /home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/lib/Catch2/src/catch2/../catch2/catch_test_macros.hpp:11,
                 from /home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/tests/unit/logic/stubs/main_loop_stub.cpp:1:
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/tests/unit/logic/stubs/main_loop_stub.cpp: In lambda function:
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/lib/Catch2/src/catch2/../catch2/internal/catch_test_macro_impl.hpp:57:67: warning: suggest parentheses around comparison in operand of ‘==’ [-Wparentheses]
   57 |             catchAssertionHandler.handleExpr( Catch::Decomposer() <= __VA_ARGS__ ); \
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/lib/Catch2/src/catch2/../catch2/internal/catch_compiler_capabilities.hpp:59:76: note: in definition of macro ‘CATCH_INTERNAL_IGNORE_BUT_WARN’
   59 | #    define CATCH_INTERNAL_IGNORE_BUT_WARN(...) (void)__builtin_constant_p(__VA_ARGS__)
      |                                                                            ^~~~~~~~~~~
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/lib/Catch2/src/catch2/../catch2/catch_test_macros.hpp:123:26: note: in expansion of macro ‘INTERNAL_CATCH_TEST’
  123 |   #define REQUIRE( ... ) INTERNAL_CATCH_TEST( "REQUIRE", Catch::ResultDisposition::Normal, __VA_ARGS__  )
      |                          ^~~~~~~~~~~~~~~~~~~
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/tests/unit/logic/stubs/main_loop_stub.cpp:181:5: note: in expansion of macro ‘REQUIRE’
  181 |     REQUIRE(WhileCondition(
      |     ^~~~~~~
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/lib/Catch2/src/catch2/../catch2/catch_test_macros.hpp:123:26: note: in expansion of macro ‘INTERNAL_CATCH_TEST’
  123 |   #define REQUIRE( ... ) INTERNAL_CATCH_TEST( "REQUIRE", Catch::ResultDisposition::Normal, __VA_ARGS__  )
      |                          ^~~~~~~~~~~~~~~~~~~
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/tests/unit/logic/stubs/main_loop_stub.cpp:184:17: note: in expansion of macro ‘REQUIRE’
  184 |                 REQUIRE(cb.Error() == ErrorCode::RUNNING); // ensure the error gets never set while disengaging the idler
      |                 ^~~~~~~
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/lib/Catch2/src/catch2/../catch2/internal/catch_test_macro_impl.hpp:57:67: warning: suggest parentheses around comparison in operand of ‘==’ [-Wparentheses]
   57 |             catchAssertionHandler.handleExpr( Catch::Decomposer() <= __VA_ARGS__ ); \
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/lib/Catch2/src/catch2/../catch2/internal/catch_compiler_capabilities.hpp:59:76: note: in definition of macro ‘CATCH_INTERNAL_IGNORE_BUT_WARN’
   59 | #    define CATCH_INTERNAL_IGNORE_BUT_WARN(...) (void)__builtin_constant_p(__VA_ARGS__)
      |                                                                            ^~~~~~~~~~~
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/lib/Catch2/src/catch2/../catch2/catch_test_macros.hpp:123:26: note: in expansion of macro ‘INTERNAL_CATCH_TEST’
  123 |   #define REQUIRE( ... ) INTERNAL_CATCH_TEST( "REQUIRE", Catch::ResultDisposition::Normal, __VA_ARGS__  )
      |                          ^~~~~~~~~~~~~~~~~~~
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/tests/unit/logic/stubs/main_loop_stub.cpp:181:5: note: in expansion of macro ‘REQUIRE’
  181 |     REQUIRE(WhileCondition(
      |     ^~~~~~~
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/lib/Catch2/src/catch2/../catch2/catch_test_macros.hpp:123:26: note: in expansion of macro ‘INTERNAL_CATCH_TEST’
  123 |   #define REQUIRE( ... ) INTERNAL_CATCH_TEST( "REQUIRE", Catch::ResultDisposition::Normal, __VA_ARGS__  )
      |                          ^~~~~~~~~~~~~~~~~~~
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/tests/unit/logic/stubs/main_loop_stub.cpp:187:17: note: in expansion of macro ‘REQUIRE’
  187 |                 REQUIRE(cb.Error() == deferredEC);
      |                 ^~~~~~~
In file included from /home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/lib/Catch2/src/catch2/../catch2/catch_test_macros.hpp:11,
                 from /home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/tests/unit/logic/stubs/main_loop_stub.cpp:1:
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/tests/unit/logic/stubs/main_loop_stub.cpp: In lambda function:
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/lib/Catch2/src/catch2/../catch2/internal/catch_test_macro_impl.hpp:57:67: warning: suggest parentheses around comparison in operand of ‘==’ [-Wparentheses]
   57 |             catchAssertionHandler.handleExpr( Catch::Decomposer() <= __VA_ARGS__ ); \
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/lib/Catch2/src/catch2/../catch2/internal/catch_test_macro_impl.hpp:61:63: note: in definition of macro ‘INTERNAL_CATCH_TEST’
   61 |     } while( (void)0, (false) && static_cast<const bool&>( !!(__VA_ARGS__) ) ) // the expression here is never evaluated at runtime but it forces the compiler to give it a look
      |                                                               ^~~~~~~~~~~
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/tests/unit/logic/stubs/main_loop_stub.cpp:181:5: note: in expansion of macro ‘REQUIRE’
  181 |     REQUIRE(WhileCondition(
      |     ^~~~~~~
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/lib/Catch2/src/catch2/../catch2/catch_test_macros.hpp:123:26: note: in expansion of macro ‘INTERNAL_CATCH_TEST’
  123 |   #define REQUIRE( ... ) INTERNAL_CATCH_TEST( "REQUIRE", Catch::ResultDisposition::Normal, __VA_ARGS__  )
      |                          ^~~~~~~~~~~~~~~~~~~
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/tests/unit/logic/stubs/main_loop_stub.cpp:184:17: note: in expansion of macro ‘REQUIRE’
  184 |                 REQUIRE(cb.Error() == ErrorCode::RUNNING); // ensure the error gets never set while disengaging the idler
      |                 ^~~~~~~
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/lib/Catch2/src/catch2/../catch2/internal/catch_test_macro_impl.hpp:57:67: warning: suggest parentheses around comparison in operand of ‘==’ [-Wparentheses]
   57 |             catchAssertionHandler.handleExpr( Catch::Decomposer() <= __VA_ARGS__ ); \
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/lib/Catch2/src/catch2/../catch2/internal/catch_test_macro_impl.hpp:61:63: note: in definition of macro ‘INTERNAL_CATCH_TEST’
   61 |     } while( (void)0, (false) && static_cast<const bool&>( !!(__VA_ARGS__) ) ) // the expression here is never evaluated at runtime but it forces the compiler to give it a look
      |                                                               ^~~~~~~~~~~
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/tests/unit/logic/stubs/main_loop_stub.cpp:181:5: note: in expansion of macro ‘REQUIRE’
  181 |     REQUIRE(WhileCondition(
      |     ^~~~~~~
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/lib/Catch2/src/catch2/../catch2/catch_test_macros.hpp:123:26: note: in expansion of macro ‘INTERNAL_CATCH_TEST’
  123 |   #define REQUIRE( ... ) INTERNAL_CATCH_TEST( "REQUIRE", Catch::ResultDisposition::Normal, __VA_ARGS__  )
      |                          ^~~~~~~~~~~~~~~~~~~
/home/runner/work/Prusa-Firmware-MMU/Prusa-Firmware-MMU/tests/unit/logic/stubs/main_loop_stub.cpp:187:17: note: in expansion of macro ‘REQUIRE’
  187 |                 REQUIRE(cb.Error() == deferredEC);
      |                 ^~~~~~~
```