### PR TITLE
CI: fix ci-build doesnt have write permission

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,17 +1,14 @@
-name: ci-build
+name: tests
 
 on:
-  pull_request:
-    branches:
-    - '*'
-  push:
+  pull_request_target:
     branches: [ main, MMU_* ]
-    tags:
-    - "v*"
 
 jobs:
-  build:
+  tests:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
 
     steps:
 
@@ -19,7 +16,7 @@ jobs:
     - name: Setup dependencies
       run: |
           sudo apt-get update
-          sudo apt-get install cmake ninja-build python3-pyelftools python3-regex python3-polib
+          sudo apt-get install gcc-11 g++11 lcov cmake ninja-build python3-pyelftools python3-regex python3-polib
 
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout ${{ github.event.pull_request.head.ref }}
@@ -51,24 +48,28 @@ jobs:
       run: sudo chmod -R 744 .dependencies
 
     - name: Build
+      id: tests_run
+      continue-on-error: true
       run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_TOOLCHAIN_FILE="../cmake/AvrGcc.cmake" -DCMAKE_BUILD_TYPE=Release -G Ninja
-          ninja
+          cmake .. -G Ninja
+          ninja test_coverage_report
+
 
     - name: Upload artifacts
-      if: ${{ !github.event.pull_request }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3.1.1
       with:
-        name: Firmware
-        path: build/*.hex
+        name: Coverage
+        path: build/Coverage
 
-    - name: RELEASE THE KRAKEN
-      if: startsWith(github.ref, 'refs/tags/v')
-      uses: "marvinpinto/action-automatic-releases@latest"
+    - name: Add PR Comment
+      if: ${{ github.event.pull_request }}
+      uses: mshick/add-pr-comment@v2.8.2
       with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        draft: true
-        files: |
-          build/autopublish/*.hex
+        message-path: build/Summary.txt
+        message-id: "coverage"
+
+    - name: Report failure
+      if: steps.tests_run.outcome == 'failure'
+      run: echo ${{ steps.tests_run.outcome  }} && test -n ""


### PR DESCRIPTION
Fixes the following error:

![image](https://github.com/user-attachments/assets/ed667a04-86e9-4d1e-81bc-43fefd5c3b42)

The trick is to use `pull_request_target`, otherwise the workflow won't have write permission on the pull request.
