### PR TITLE
tests: improvements around idler homing

### DIFF
--- a/tests/unit/logic/load_filament/test_load_filament.cpp
+++ b/tests/unit/logic/load_filament/test_load_filament.cpp
@@ -84,6 +84,13 @@ void LoadFilamentSuccessful(uint8_t slot, logic::LoadFilament &lf) {
 void LoadFilamentSuccessfulWithRehomeSelector(uint8_t slot, logic::LoadFilament &lf) {
     // Stage 2 - feeding to finda
     // make FINDA switch on
+    // engaging idler
+
+    REQUIRE(WhileCondition(
+        lf,
+        [&](uint32_t) { return !mi::idler.Engaged(); },
+        5000));
+
     REQUIRE(WhileCondition(lf, std::bind(SimulateFeedToFINDA, _1, 100), 5000));
     REQUIRE(VerifyState(lf, mg::FilamentLoadState::InSelector, slot, slot, true, true, ml::blink0, ml::off, ErrorCode::RUNNING, ProgressCode::RetractingFromFinda));
 
@@ -175,8 +182,6 @@ void FailedLoadToFindaResolveTryAgain(uint8_t slot, logic::LoadFilament &lf) {
     // Idler's position needs to be ignored as it has started homing after the button press
     REQUIRE(VerifyState(lf, mg::FilamentLoadState::InSelector, config::toolCount, slot, false, false, ml::blink0, ml::off, ErrorCode::RUNNING, ProgressCode::FeedingToFinda));
     ClearButtons(lf);
-
-    SimulateIdlerHoming(lf);
 
     LoadFilamentSuccessfulWithRehomeSelector(slot, lf);
 }

--- a/tests/unit/logic/stubs/homing.cpp
+++ b/tests/unit/logic/stubs/homing.cpp
@@ -1,3 +1,4 @@
+#include "catch2/catch_test_macros.hpp"
 #include "homing.h"
 #include "main_loop_stub.h"
 
@@ -185,33 +186,40 @@ bool SimulateFailedHomeSelectorPostfix(logic::CommandBase &cb) {
 }
 
 bool SimulateFailedHomeFirstTime(logic::CommandBase &cb) {
-    if (mi::idler.HomingValid())
-        return false;
-    if (ms::selector.HomingValid())
-        return false;
+    REQUIRE(!mi::idler.HomingValid());
+    REQUIRE(!ms::selector.HomingValid());
+
+    // Idler homing is successful
+    SimulateIdlerHoming(cb);
+    SimulateIdlerWaitForHomingValid(cb);
+
+    // Selector homes once the idler homing is valid.
+    REQUIRE(mi::idler.HomingValid());
+    REQUIRE(!ms::selector.HomingValid());
+
+    // The selector will only rehome once the idler homing is valid. At that moment
+    // the state will change to HomeForward.
+    REQUIRE(WhileCondition(
+        cb,
+        [&](uint32_t) { return ms::selector.State() != mm::MovableBase::HomeForward; },
+        5000));
 
     constexpr uint32_t selectorSteps = mm::unitToSteps<mm::S_pos_t>(config::selectorLimits.lenght) + 1;
     {
         // do 5 steps until we trigger the simulated StallGuard
-        constexpr uint32_t idlerStepsFwd = mm::unitToSteps<mm::I_pos_t>(config::idlerLimits.lenght - 5.0_deg);
-        static_assert(idlerStepsFwd < selectorSteps); // beware, we expect that the Idler homes faster than Selector (less steps)
-        for (uint32_t i = 0; i < idlerStepsFwd; ++i) {
+        for (uint32_t i = 0; i < selectorSteps; ++i) {
             main_loop();
             cb.Step();
         }
 
         mm::TriggerStallGuard(mm::Selector);
-        mm::TriggerStallGuard(mm::Idler);
         main_loop();
         cb.Step();
         mm::motion.StallGuardReset(mm::Selector);
-        mm::motion.StallGuardReset(mm::Idler);
     }
-    // now do a correct amount of steps of each axis towards the other end
-    constexpr uint32_t idlerSteps = mm::unitToSteps<mm::I_pos_t>(config::idlerLimits.lenght);
-    // now do LESS steps than expected to simulate something is blocking the selector
 
-    constexpr uint32_t selectorTriggerShort = std::min(idlerSteps, selectorSteps) / 2;
+    // now do LESS steps than expected to simulate something is blocking the selector
+    constexpr uint32_t selectorTriggerShort = selectorSteps / 2;
     constexpr uint32_t maxSteps = selectorTriggerShort + 1;
     {
         for (uint32_t i = 0; i < maxSteps; ++i) {
@@ -222,17 +230,6 @@ bool SimulateFailedHomeFirstTime(logic::CommandBase &cb) {
                 mm::TriggerStallGuard(mm::Selector);
             } else {
                 mm::motion.StallGuardReset(mm::Selector);
-            }
-        }
-
-        // make sure the Idler finishes its homing procedure (makes further checks much easier)
-        for (uint32_t i = maxSteps; i < idlerSteps + 1; ++i) {
-            main_loop();
-            cb.Step();
-            if (i == idlerSteps) {
-                mm::TriggerStallGuard(mm::Idler);
-            } else {
-                mm::motion.StallGuardReset(mm::Idler);
             }
         }
 


### PR DESCRIPTION
The changes were made in https://github.com/prusa3d/Prusa-Firmware-MMU/pull/337 but I'm creating this separate PR since these changes apply to the current main branch.

Changes:

1. Remove `SimulateIdlerHoming` call in Load Filament error recovery. The homing is never invalidated in this state machine. Instead we should be simulating the idler engaging on the slot with the error.
2. Fix an issue in the unit tests where if homing fails with state `mm::MovableBase::HomingFailed` then the unit test will timeout. Also added checks for `mm::MovableBase::HomeForward` and `mm::MovableBase::HomeBack`.
3. Simplify `SimulateFailedHomeFirstTime`, it was attempting to homing the idler and selector at the same time... which is forbidden today. Instead, simulate a successful idler homing, and proceed to simulate a failed selector homing.