### PR TITLE
pulley: `HomeBack` state is never used

### DIFF
--- a/src/modules/pulley.cpp
+++ b/src/modules/pulley.cpp
@@ -11,11 +11,6 @@ namespace pulley {
 
 Pulley pulley;
 
-bool __attribute__((noinline)) Pulley::FinishHomingAndPlanMoveToParkPos() {
-    mm::motion.SetPosition(mm::Pulley, 0);
-    return true;
-}
-
 bool Pulley::Step() {
     if (IsOnHold()) {
         return true; // just wait, do nothing!
@@ -28,10 +23,6 @@ bool Pulley::Step() {
     case Moving:
         PerformMove();
         return false;
-    case HomeBack:
-        homingValid = true;
-        FinishHomingAndPlanMoveToParkPos();
-        return true;
     case Ready:
         return true;
     case TMCFailed:

--- a/src/modules/pulley.h
+++ b/src/modules/pulley.h
@@ -44,7 +44,7 @@ protected:
     virtual void PrepareMoveToPlannedSlot() override {}
     virtual void PlanHomingMoveForward() override {}
     virtual void PlanHomingMoveBack() override {}
-    virtual bool FinishHomingAndPlanMoveToParkPos() override;
+    virtual bool FinishHomingAndPlanMoveToParkPos() override { return true; }
     virtual void FinishMove() override {}
 };
 


### PR DESCRIPTION
Idea to save flash memory.

I don't see `HomeBack` being set for the pulley anywhere. `FinishHomingAndPlanMoveToParkPos` function is only used if StallGuard detects a stall event.