### PR TITLE
Fix issue with MMU2S not loading filament correctly (related to issue #332)

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -201,7 +201,8 @@ static constexpr IdlerLimits idlerLimits = {
 };
 
 static constexpr U_deg IdlerSlotDistance = 40.0_deg; /// Idler distance between two slots
-static constexpr U_deg IdlerOffsetFromHome = 18.0_deg; /// Idler offset from home to slots
+// RCU Test Patch MMU2S : adapted home offset from 18 to 25 deg
+static constexpr U_deg IdlerOffsetFromHome = 25.0_deg; /// Idler offset from home to slots
 
 /// Absolute positions for Idler's slots: 0-4 are the real ones, the 5th index is the idle position
 /// Home ccw with 5th idler bearing facing selector


### PR DESCRIPTION
Adapted angle to fix load issue on MMU2S (lot of load failures). Since firmware rebuild with this new angle, I do not have any load issue - lot of print made using PETG with this adapted version). To test on MMU3S as I do not have such device at home.

Fixed the issue #332 