### PR TITLE
Optimize MMU behaviour

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -104,6 +104,7 @@ static constexpr U_mm pulleyHelperMove = 10.0_mm; ///< Helper move for Load/Unlo
 static constexpr U_mm cutLength = 8.0_mm;
 static constexpr U_mm fsensorToNozzle = 30.0_mm; ///< ~20mm from MK4's filament sensor through extruder gears into nozzle
 static constexpr U_mm fsensorToNozzleAvoidGrind = 5.0_mm;
+static constexpr U_mm fsensorToNozzleAvoidGrindUnload = 20.0_mm;
 /// Check the state of FSensor after this amount of filament got (hopefully) pulled out while unloading.
 static constexpr U_mm fsensorUnloadCheckDistance = 40.0_mm;
 

--- a/src/logic/command_base.cpp
+++ b/src/logic/command_base.cpp
@@ -212,7 +212,7 @@ void CommandBase::ErrDisengagingIdler() {
 void CommandBase::GoToErrDisengagingIdler(ErrorCode deferredEC) {
     state = ProgressCode::ERRDisengagingIdler;
     deferredErrorCode = deferredEC;
-    ml::leds.SetPairButOffOthers(mg::globals.ActiveSlot(), ml::off, ml::blink0);
+    ml::leds.ActiveSlotError();
     mi::idler.Disengage();
 }
 

--- a/src/logic/cut_filament.cpp
+++ b/src/logic/cut_filament.cpp
@@ -94,7 +94,7 @@ bool CutFilament::StepInner() {
     case ProgressCode::PreparingBlade:
         if (ms::selector.Slot() == cutSlot + 1) {
             state = ProgressCode::PushingFilament;
-            mpu::pulley.PlanMove(mg::globals.CutLength() + config::cuttingEdgeRetract, config::pulleySlowFeedrate);
+            mpu::pulley.PlanMove(mg::globals.CutLength() + config::cuttingEdgeRetract, mg::globals.PulleySlowFeedrate_mm_s());
         }
         break;
     case ProgressCode::PushingFilament:
@@ -123,7 +123,7 @@ bool CutFilament::StepInner() {
             // revert move speed
             mg::globals.SetSelectorFeedrate_mm_s(savedSelectorFeedRate_mm_s);
             ms::selector.InvalidateHoming();
-            mpu::pulley.PlanMove(-config::cuttingEdgeRetract, config::pulleySlowFeedrate);
+            mpu::pulley.PlanMove(-config::cuttingEdgeRetract, mg::globals.PulleySlowFeedrate_mm_s());
         }
         break;
     case ProgressCode::Homing:

--- a/src/logic/cut_filament.cpp
+++ b/src/logic/cut_filament.cpp
@@ -86,7 +86,7 @@ bool CutFilament::StepInner() {
                 // move selector aside - prepare the blade into active position
                 state = ProgressCode::PreparingBlade;
                 mg::globals.SetFilamentLoaded(cutSlot, mg::FilamentLoadState::AtPulley);
-                ml::leds.SetPairButOffOthers(mg::globals.ActiveSlot(), ml::blink0, ml::off);
+                ml::leds.ActiveSlotProcessing();
                 MoveSelector(cutSlot + 1);
             }
         }
@@ -134,7 +134,7 @@ bool CutFilament::StepInner() {
     case ProgressCode::ReturningSelector:
         if (ms::selector.State() == ms::selector.Ready) {
             FinishedOK();
-            ml::leds.SetPairButOffOthers(mg::globals.ActiveSlot(), ml::on, ml::off);
+            ml::leds.ActiveSlotDonePrimed();
         }
         break;
     case ProgressCode::OK:

--- a/src/logic/eject_filament.cpp
+++ b/src/logic/eject_filament.cpp
@@ -61,7 +61,7 @@ bool EjectFilament::StepInner() {
         if (mi::idler.Engaged()) {
             state = ProgressCode::EjectingFilament;
             mpu::pulley.InitAxis();
-            mpu::pulley.PlanMove(config::ejectFromCuttingEdge, config::pulleySlowFeedrate);
+            mpu::pulley.PlanMove(config::ejectFromCuttingEdge, mg::globals.PulleySlowFeedrate_mm_s());
         }
         break;
     case ProgressCode::EjectingFilament:

--- a/src/logic/feed_to_bondtech.cpp
+++ b/src/logic/feed_to_bondtech.cpp
@@ -17,7 +17,7 @@ void FeedToBondtech::Reset(uint8_t maxRetries) {
     dbg_logic_P(PSTR("\nFeed to Bondtech\n\n"));
     state = EngagingIdler;
     this->maxRetries = maxRetries;
-    ml::leds.SetMode(mg::globals.ActiveSlot(), ml::green, ml::blink0);
+    ml::leds.SetPairButOffOthers(mg::globals.ActiveSlot(), ml::blink0, ml::off);
     mi::idler.Engage(mg::globals.ActiveSlot());
 }
 

--- a/src/logic/feed_to_bondtech.cpp
+++ b/src/logic/feed_to_bondtech.cpp
@@ -78,7 +78,7 @@ bool FeedToBondtech::Step() {
             mg::globals.SetFilamentLoaded(mg::globals.ActiveSlot(), mg::FilamentLoadState::InNozzle);
             mi::idler.PartiallyDisengage(mg::globals.ActiveSlot());
             // while disengaging the idler, keep on moving with the pulley to avoid grinding while the printer is trying to grab the filament itself
-            mpu::pulley.PlanMove(config::fsensorToNozzleAvoidGrind, config::pulleySlowFeedrate);
+            mpu::pulley.PlanMove(config::fsensorToNozzleAvoidGrind, mg::globals.PulleySlowFeedrate_mm_s());
             state = PartiallyDisengagingIdler;
         }
         return false;

--- a/src/logic/feed_to_bondtech.cpp
+++ b/src/logic/feed_to_bondtech.cpp
@@ -17,7 +17,7 @@ void FeedToBondtech::Reset(uint8_t maxRetries) {
     dbg_logic_P(PSTR("\nFeed to Bondtech\n\n"));
     state = EngagingIdler;
     this->maxRetries = maxRetries;
-    ml::leds.SetPairButOffOthers(mg::globals.ActiveSlot(), ml::blink0, ml::off);
+    ml::leds.ActiveSlotProcessing();
     mi::idler.Engage(mg::globals.ActiveSlot());
 }
 
@@ -95,7 +95,7 @@ bool FeedToBondtech::Step() {
             dbg_logic_P(PSTR("Feed to Bondtech --> Idler disengaged"));
             dbg_logic_fP(PSTR("Pulley end steps %u"), mpu::pulley.CurrentPosition_mm());
             state = OK;
-            ml::leds.SetMode(mg::globals.ActiveSlot(), ml::green, ml::on);
+            ml::leds.ActiveSlotDonePrimed();
         }
         return false;
     case OK:

--- a/src/logic/feed_to_finda.cpp
+++ b/src/logic/feed_to_finda.cpp
@@ -17,7 +17,7 @@ bool FeedToFinda::Reset(bool feedPhaseLimited, bool haltAtEnd) {
     state = EngagingIdler;
     this->feedPhaseLimited = feedPhaseLimited;
     this->haltAtEnd = haltAtEnd;
-    ml::leds.SetPairButOffOthers(mg::globals.ActiveSlot(), ml::blink0, ml::off);
+    ml::leds.ActiveSlotProcessing();
     if (ms::selector.MoveToSlot(mg::globals.ActiveSlot()) != ms::Selector::OperationResult::Accepted) {
         // We can't get any FINDA readings if the selector is at the wrong spot - move it accordingly if necessary
         // And prevent issuing any commands to the idler in such an error state
@@ -68,7 +68,7 @@ bool FeedToFinda::Step() {
             return true; // return immediately to allow for a seamless planning of another move (like feeding to bondtech)
         } else if (mm::motion.QueueEmpty()) { // all moves have been finished and FINDA didn't switch on
             state = Failed;
-            ml::leds.SetPairButOffOthers(mg::globals.ActiveSlot(), ml::off, ml::blink0);
+            ml::leds.ActiveSlotError();
         }
     }
         return false;

--- a/src/logic/feed_to_finda.cpp
+++ b/src/logic/feed_to_finda.cpp
@@ -44,14 +44,14 @@ bool FeedToFinda::Step() {
             //                mpu::pulley.PlanMove(config::filamentMinLoadedToMMU, config::pulleySlowFeedrate);
             //            }
 
-            mpu::pulley.PlanMove(config::maximumFeedToFinda, config::pulleySlowFeedrate);
+            mpu::pulley.PlanMove(config::maximumFeedToFinda, mg::globals.PulleySlowFeedrate_mm_s());
             if (feedPhaseLimited) {
                 state = PushingFilament;
             } else {
                 state = PushingFilamentUnlimited;
                 // in unlimited move we plan 2 moves at once to make the move "seamless"
                 // one move has already been planned above, this is the second one
-                mpu::pulley.PlanMove(config::maximumFeedToFinda, config::pulleySlowFeedrate);
+                mpu::pulley.PlanMove(config::maximumFeedToFinda, mg::globals.PulleySlowFeedrate_mm_s());
             }
             mg::globals.SetFilamentLoaded(mg::globals.ActiveSlot(), mg::FilamentLoadState::InSelector);
             mui::userInput.Clear(); // remove all buffered events if any just before we wait for some input
@@ -85,7 +85,7 @@ bool FeedToFinda::Step() {
             return true; // return immediately to allow for a seamless planning of another move (like feeding to bondtech)
         } else if (mm::motion.PlannedMoves(mm::Pulley) < 2) {
             // plan another move to make the illusion of unlimited moves
-            mpu::pulley.PlanMove(config::maximumFeedToFinda, config::pulleySlowFeedrate);
+            mpu::pulley.PlanMove(config::maximumFeedToFinda, mg::globals.PulleySlowFeedrate_mm_s());
         }
     }
         return false;

--- a/src/logic/load_filament.cpp
+++ b/src/logic/load_filament.cpp
@@ -50,8 +50,6 @@ void logic::LoadFilament::Reset2(bool feedPhaseLimited) {
     if (!feed.Reset(feedPhaseLimited, true)) {
         // selector refused to move
         GoToErrDisengagingIdler(ErrorCode::FINDA_FLICKERS);
-    } else {
-        ml::leds.SetPairButOffOthers(mg::globals.ActiveSlot(), ml::blink0, ml::off);
     }
 }
 

--- a/src/logic/retract_from_finda.cpp
+++ b/src/logic/retract_from_finda.cpp
@@ -13,7 +13,7 @@ namespace logic {
 void RetractFromFinda::Reset() {
     dbg_logic_P(PSTR("\nRetract from FINDA\n\n"));
     state = EngagingIdler;
-    ml::leds.SetPairButOffOthers(mg::globals.ActiveSlot(), ml::blink0, ml::off);
+    ml::leds.ActiveSlotProcessing();
     mi::idler.Engage(mg::globals.ActiveSlot());
 }
 
@@ -33,10 +33,10 @@ bool RetractFromFinda::Step() {
                 state = OK;
                 mg::globals.SetFilamentLoaded(mg::globals.ActiveSlot(), mg::FilamentLoadState::AtPulley);
                 dbg_logic_fP(PSTR("Pulley end steps %u"), mpu::pulley.CurrentPosition_mm());
-                ml::leds.SetMode(mg::globals.ActiveSlot(), ml::green, ml::off);
+                ml::leds.ActiveSlotDoneEmpty();
             } else { // FINDA didn't switch off
                 state = Failed;
-                ml::leds.SetPairButOffOthers(mg::globals.ActiveSlot(), ml::off, ml::blink0);
+                ml::leds.ActiveSlotError();
             }
         }
         return false;

--- a/src/logic/tool_change.cpp
+++ b/src/logic/tool_change.cpp
@@ -54,20 +54,19 @@ bool ToolChange::Reset(uint8_t param) {
     return true;
 }
 
-void logic::ToolChange::GoToFeedingToBondtech() {
-    ml::leds.SetPairButOffOthers(mg::globals.ActiveSlot(), ml::blink0, ml::off);
+void ToolChange::GoToFeedingToBondtech() {
     james.Reset(3);
     state = ProgressCode::FeedingToBondtech;
     error = ErrorCode::RUNNING;
 }
 
-void logic::ToolChange::ToolChangeFinishedCorrectly() {
-    ml::leds.SetPairButOffOthers(mg::globals.ActiveSlot(), ml::on, ml::off);
+void ToolChange::ToolChangeFinishedCorrectly() {
+    ml::leds.ActiveSlotDonePrimed();
     mui::userInput.SetPrinterInCharge(false);
     FinishedOK();
 }
 
-void logic::ToolChange::GoToFeedingToFinda() {
+void ToolChange::GoToFeedingToFinda() {
     state = ProgressCode::FeedingToFinda;
     error = ErrorCode::RUNNING;
     mg::globals.SetFilamentLoaded(plannedSlot, mg::FilamentLoadState::AtPulley);

--- a/src/logic/tool_change.cpp
+++ b/src/logic/tool_change.cpp
@@ -39,7 +39,7 @@ bool ToolChange::Reset(uint8_t param) {
     if (mg::globals.FilamentLoaded() >= mg::FilamentLoadState::InSelector) {
         dbg_logic_P(PSTR("Filament is loaded --> unload"));
         state = ProgressCode::UnloadingFilament;
-        unl.Reset(mg::globals.ActiveSlot());
+        unl.Reset2(mg::globals.ActiveSlot());
     } else {
         mg::globals.SetFilamentLoaded(plannedSlot, mg::FilamentLoadState::InSelector); // activate the correct slot, feed uses that
         if (feed.Reset(true, false)) {

--- a/src/logic/unload_filament.cpp
+++ b/src/logic/unload_filament.cpp
@@ -30,7 +30,6 @@ bool UnloadFilament::Reset(uint8_t /*param*/) {
     error = ErrorCode::RUNNING;
     skipDisengagingIdler = false;
     unl.Reset(maxRetries);
-    ml::leds.SetAllOff();
     return true;
 }
 

--- a/src/logic/unload_filament.h
+++ b/src/logic/unload_filament.h
@@ -12,11 +12,14 @@ namespace logic {
 class UnloadFilament : public CommandBase {
 public:
     inline constexpr UnloadFilament()
-        : CommandBase() {}
+        : CommandBase()
+        , skipDisengagingIdler(false) {}
 
     /// Restart the automaton
     /// @param param is not used, always unloads from the active slot
     bool Reset(uint8_t param) override;
+
+    bool Reset2(uint8_t param);
 
     /// @returns true if the state machine finished its job, false otherwise
     bool StepInner() override;
@@ -32,6 +35,7 @@ private:
     UnloadToFinda unl;
     FeedToFinda feed;
     RetractFromFinda retract;
+    bool skipDisengagingIdler;
 };
 
 /// The one and only instance of UnloadFilament state machine in the FW

--- a/src/logic/unload_to_finda.cpp
+++ b/src/logic/unload_to_finda.cpp
@@ -87,7 +87,10 @@ bool UnloadToFinda::Step() {
             // we reached the end of move queue, but the FINDA didn't switch off
             // two possible causes - grinded filament or malfunctioning FINDA
             if (--maxTries) {
-                Reset(maxTries); // try again
+                // Ideally, the Idler shall rehome and then try again.
+                // That would auto-resolve errors caused by slipped or misaligned Idler
+                mi::idler.InvalidateHoming();
+                Reset(maxTries);
             } else {
                 state = FailedFINDA;
             }

--- a/src/logic/unload_to_finda.cpp
+++ b/src/logic/unload_to_finda.cpp
@@ -22,7 +22,7 @@ void UnloadToFinda::Reset(uint8_t maxTries) {
         state = EngagingIdler;
         mi::idler.PartiallyDisengage(mg::globals.ActiveSlot()); // basically prepare before the active slot - saves ~1s
         started_ms = mt::timebase.Millis();
-        ml::leds.SetPairButOffOthers(mg::globals.ActiveSlot(), ml::blink0, ml::off);
+        ml::leds.ActiveSlotProcessing();
     }
 }
 
@@ -77,12 +77,12 @@ bool UnloadToFinda::Step() {
             // This scenario should not be tried again - repeating it may cause more damage to filament + potentially more collateral damage
             state = FailedFSensor;
             mm::motion.AbortPlannedMoves(); // stop rotating the pulley
-            ml::leds.SetMode(mg::globals.ActiveSlot(), ml::green, ml::off);
+            ml::leds.ActiveSlotDoneEmpty();
         } else if (!mf::finda.Pressed()) {
             // detected end of filament
             state = OK;
             mm::motion.AbortPlannedMoves(); // stop rotating the pulley
-            ml::leds.SetMode(mg::globals.ActiveSlot(), ml::green, ml::off);
+            ml::leds.ActiveSlotDoneEmpty();
         } else if (/*tmc2130_read_gstat() &&*/ mm::motion.QueueEmpty()) {
             // we reached the end of move queue, but the FINDA didn't switch off
             // two possible causes - grinded filament or malfunctioning FINDA

--- a/src/logic/unload_to_finda.cpp
+++ b/src/logic/unload_to_finda.cpp
@@ -22,6 +22,7 @@ void UnloadToFinda::Reset(uint8_t maxTries) {
         state = EngagingIdler;
         mi::idler.PartiallyDisengage(mg::globals.ActiveSlot()); // basically prepare before the active slot - saves ~1s
         started_ms = mt::timebase.Millis();
+        ml::leds.SetPairButOffOthers(mg::globals.ActiveSlot(), ml::blink0, ml::off);
     }
 }
 
@@ -46,7 +47,6 @@ bool UnloadToFinda::Step() {
             if (mg::globals.FilamentLoaded() >= mg::FilamentLoadState::InSelector) {
                 state = UnloadingToFinda;
                 mpu::pulley.InitAxis();
-                ml::leds.SetMode(mg::globals.ActiveSlot(), ml::green, ml::blink0);
                 mi::idler.Engage(mg::globals.ActiveSlot());
 
                 //  slow move for the first few millimeters - help the printer relieve the filament while engaging the Idler fully

--- a/src/logic/unload_to_finda.cpp
+++ b/src/logic/unload_to_finda.cpp
@@ -25,6 +25,11 @@ void UnloadToFinda::Reset(uint8_t maxTries) {
 
 bool UnloadToFinda::Step() {
     switch (state) {
+    // start by engaging the idler into intermediate position
+    // Then, wait for !fsensor.Pressed: that's to speed-up the pull process - unload operation will be started during the purging moves
+    // and as soon as the fsensor turns off, the MMU engages the idler fully and starts pulling.
+    // It will not wait for the extruder to finish the relieve move.
+    // However, such an approach breaks running the MMU on a non-reworked MK4/C1, which hasn't been officially supported, but possible (with some level of uncertainity).
     case EngagingIdler:
         if (mg::globals.FilamentLoaded() >= mg::FilamentLoadState::InSelector) {
             state = UnloadingToFinda;

--- a/src/logic/unload_to_finda.cpp
+++ b/src/logic/unload_to_finda.cpp
@@ -48,6 +48,9 @@ bool UnloadToFinda::Step() {
                 mpu::pulley.InitAxis();
                 ml::leds.SetMode(mg::globals.ActiveSlot(), ml::green, ml::blink0);
                 mi::idler.Engage(mg::globals.ActiveSlot());
+
+                //  slow move for the first few millimeters - help the printer relieve the filament while engaging the Idler fully
+                mpu::pulley.PlanMove(-config::fsensorToNozzleAvoidGrindUnload, mg::globals.PulleySlowFeedrate_mm_s(), mg::globals.PulleySlowFeedrate_mm_s());
             } else {
                 state = FailedFINDA;
             }

--- a/src/logic/unload_to_finda.h
+++ b/src/logic/unload_to_finda.h
@@ -24,7 +24,8 @@ struct UnloadToFinda {
     inline constexpr UnloadToFinda()
         : state(OK)
         , maxTries(3)
-        , unloadStart_mm(0) {}
+        , unloadStart_mm(0)
+        , started_ms(0) {}
 
     /// Restart the automaton
     /// @param maxTries maximum number of retried attempts before reporting a fail
@@ -40,6 +41,7 @@ private:
     uint8_t state;
     uint8_t maxTries;
     int32_t unloadStart_mm; // intentionally trying to avoid using U_mm because it is a float (reps. long double)
+    uint16_t started_ms; // timeout on fsensor turn off
 };
 
 } // namespace logic

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,7 +125,7 @@ static void setup2() {
 
         // activate the correct LED if filament is present
         if (mg::globals.FilamentLoaded() > mg::FilamentLoadState::AtPulley) {
-            ml::leds.SetMode(mg::globals.ActiveSlot(), ml::green, ml::on);
+            ml::leds.ActiveSlotDonePrimed();
         }
     }
 

--- a/src/modules/idler.cpp
+++ b/src/modules/idler.cpp
@@ -104,7 +104,7 @@ Idler::OperationResult Idler::PlanMoveInner(uint8_t slot, Operation plannedOp) {
     }
 
     // already engaged or disengaged
-    if (currentlyEngaged == plannedMove) {
+    if (currentlyEngaged == plannedMove && currentSlot == plannedSlot) {
         return OperationResult::Accepted;
     }
 

--- a/src/modules/leds.cpp
+++ b/src/modules/leds.cpp
@@ -2,6 +2,7 @@
 #include "leds.h"
 #include "../hal/shr16.h"
 #include "timebase.h"
+#include "globals.h"
 
 namespace modules {
 namespace leds {
@@ -66,6 +67,22 @@ void LEDs::SetAllOff() {
         SetMode(i, ml::green, ml::off);
         SetMode(i, ml::red, ml::off);
     }
+}
+
+void LEDs::ActiveSlotProcessing() {
+    SetPairButOffOthers(mg::globals.ActiveSlot(), ml::blink0, ml::off);
+}
+
+void LEDs::ActiveSlotError() {
+    SetPairButOffOthers(mg::globals.ActiveSlot(), ml::off, ml::blink0);
+}
+
+void LEDs::ActiveSlotDoneEmpty() {
+    SetPairButOffOthers(mg::globals.ActiveSlot(), ml::off, ml::off);
+}
+
+void LEDs::ActiveSlotDonePrimed() {
+    SetPairButOffOthers(mg::globals.ActiveSlot(), ml::on, ml::off);
 }
 
 } // namespace leds

--- a/src/modules/leds.h
+++ b/src/modules/leds.h
@@ -122,6 +122,14 @@ public:
     /// Turn off all LEDs
     void SetAllOff();
 
+    /// Convenience functions - provide uniform implementation of LED behaviour through all the logic commands.
+    /// Intentionally not inlined to save quite some space (140B)
+    /// It's not a clean solution, LEDs should not know about mg::globals.ActiveSlot(), but the savings are important
+    void ActiveSlotProcessing();
+    void ActiveSlotError();
+    void ActiveSlotDoneEmpty();
+    void ActiveSlotDonePrimed();
+
 private:
     constexpr static const uint8_t ledPairs = config::toolCount;
     /// pairs of LEDs:

--- a/tests/unit/logic/failing_tmc/test_failing_tmc.cpp
+++ b/tests/unit/logic/failing_tmc/test_failing_tmc.cpp
@@ -51,7 +51,7 @@ void FailingMovableUnload(hal::tmc2130::ErrorFlags ef, ErrorCode ec, config::Axi
     // UnloadFilament starts by engaging the idler (through the UnloadToFinda state machine)
     uf.Reset(0);
 
-    REQUIRE(VerifyState(uf, mg::FilamentLoadState::InNozzle, mi::Idler::IdleSlotIndex(), 0, true, true, ml::off, ml::off, ErrorCode::RUNNING, ProgressCode::UnloadingToFinda));
+    REQUIRE(VerifyState(uf, mg::FilamentLoadState::InNozzle, mi::Idler::IdleSlotIndex(), 0, true, true, ml::blink0, ml::off, ErrorCode::RUNNING, ProgressCode::UnloadingToFinda));
 
     REQUIRE(WhileCondition(
         uf,

--- a/tests/unit/logic/stubs/main_loop_stub.cpp
+++ b/tests/unit/logic/stubs/main_loop_stub.cpp
@@ -79,19 +79,27 @@ void ForceReinitAllAutomata() {
     mg::globals.Init();
     mg::globals.SetFilamentLoaded(mg::globals.ActiveSlot(), mg::FilamentLoadState::AtPulley);
 }
+void HomeIdler() {
+    logic::NoCommand nc; // just a dummy instance which has an empty Step()
+    SimulateIdlerHoming(nc);
+    SimulateIdlerWaitForHomingValid(nc);
+    SimulateIdlerMoveToParkingPosition(nc);
+}
+
+void HomeSelector() {
+    logic::NoCommand nc; // just a dummy instance which has an empty Step()
+    SimulateSelectorHoming(nc);
+    SimulateSelectorWaitForHomingValid(nc);
+    SimulateSelectorWaitForReadyState(nc);
+}
 
 void HomeIdlerAndSelector() {
     mi::idler.InvalidateHoming();
     ms::selector.InvalidateHoming();
-    logic::NoCommand nc; // just a dummy instance which has an empty Step()
 
-    SimulateIdlerHoming(nc);
-    SimulateIdlerWaitForHomingValid(nc);
-    SimulateIdlerMoveToParkingPosition(nc);
+    HomeIdler();
 
-    SimulateSelectorHoming(nc);
-    SimulateSelectorWaitForHomingValid(nc);
-    SimulateSelectorWaitForReadyState(nc);
+    HomeSelector();
 }
 
 bool EnsureActiveSlotIndex(uint8_t slot, mg::FilamentLoadState loadState) {

--- a/tests/unit/logic/stubs/main_loop_stub.h
+++ b/tests/unit/logic/stubs/main_loop_stub.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "../../../../src/logic/command_base.h"
 #include "../../../../src/modules/globals.h"
+#include "../../../../src/modules/idler.h"
 
 extern void main_loop();
 extern void ForceReinitAllAutomata();
@@ -44,3 +45,21 @@ static constexpr uint32_t selectorMoveMaxSteps = 40000UL;
 void HomeIdlerAndSelector();
 
 void SimulateErrDisengagingIdler(logic::CommandBase &cb, ErrorCode deferredEC);
+
+template <typename T>
+bool SimulateEngageIdlerFully(T &cb) {
+    return WhileCondition(
+        cb,
+        [&](uint32_t) { return !mi::idler.Engaged(); },
+        5000);
+}
+
+template <typename T>
+bool SimulateEngageIdlerPartially(T &cb) {
+    return WhileCondition(
+        cb,
+        [&](uint32_t) { return !mi::idler.PartiallyDisengaged(); },
+        5000);
+}
+
+void HomeIdler();

--- a/tests/unit/logic/tool_change/test_tool_change.cpp
+++ b/tests/unit/logic/tool_change/test_tool_change.cpp
@@ -328,7 +328,7 @@ void ToolChangeFailFSensor(logic::ToolChange &tc, uint8_t fromSlot, uint8_t toSl
     // restart the automaton
     tc.Reset(toSlot);
 
-    REQUIRE(VerifyState(tc, mg::FilamentLoadState::InNozzle, mi::idler.IdleSlotIndex(), fromSlot, true, true, ml::off, ml::off, ErrorCode::RUNNING, ProgressCode::UnloadingFilament));
+    REQUIRE(VerifyState(tc, mg::FilamentLoadState::InNozzle, mi::idler.IdleSlotIndex(), fromSlot, true, true, ml::blink0, ml::off, ErrorCode::RUNNING, ProgressCode::UnloadingFilament));
     // simulate unload to finda but fail the fsensor test
     REQUIRE(WhileCondition(tc, std::bind(SimulateUnloadToFINDA, _1, 500'000, 10'000), 200'000));
     REQUIRE(VerifyState(tc, mg::FilamentLoadState::InSelector, mi::idler.IdleSlotIndex(), fromSlot, false, false, ml::off, ml::blink0, ErrorCode::FSENSOR_DIDNT_SWITCH_OFF, ProgressCode::UnloadingFilament));
@@ -528,7 +528,7 @@ void ToolChangeFSENSOR_TOO_EARLY(logic::ToolChange &tc, uint8_t slot) {
 
     // make AutoRetry
     PressButtonAndDebounce(tc, mb::Middle, true);
-    REQUIRE(VerifyState(tc, mg::FilamentLoadState::InSelector, mi::idler.IdleSlotIndex(), slot, true, true, ml::off, ml::off, ErrorCode::RUNNING, ProgressCode::UnloadingFilament));
+    REQUIRE(VerifyState(tc, mg::FilamentLoadState::InSelector, mi::idler.IdleSlotIndex(), slot, true, true, ml::blink0, ml::off, ErrorCode::RUNNING, ProgressCode::UnloadingFilament));
 
     SimulateIdlerHoming(tc);
 

--- a/tests/unit/modules/leds/CMakeLists.txt
+++ b/tests/unit/modules/leds/CMakeLists.txt
@@ -1,7 +1,13 @@
 # define the test executable
 add_executable(
-  leds_tests ${CMAKE_SOURCE_DIR}/src/modules/leds.cpp ${MODULES_STUBS_DIR}/stub_shr16.cpp
-             ${MODULES_STUBS_DIR}/stub_timebase.cpp test_leds.cpp
+  leds_tests
+  ${CMAKE_SOURCE_DIR}/src/modules/leds.cpp
+  ${CMAKE_SOURCE_DIR}/src/modules/globals.cpp
+  ${CMAKE_SOURCE_DIR}/src/modules/permanent_storage.cpp
+  ${MODULES_STUBS_DIR}/stub_shr16.cpp
+  ${MODULES_STUBS_DIR}/stub_timebase.cpp
+  ${MODULES_STUBS_DIR}/stub_eeprom.cpp
+  test_leds.cpp
   )
 
 # define required search paths

--- a/version.cmake
+++ b/version.cmake
@@ -10,6 +10,6 @@ set(PROJECT_VERSION_MINOR
     CACHE STRING "Project minor version" FORCE
     )
 set(PROJECT_VERSION_REV
-    3
+    4
     CACHE STRING "Project revision" FORCE
     )


### PR DESCRIPTION
This PR is a collection of improvements in order to make tool changing even faster.
Of course, a corresponding counterpart on the printer's side will be necessary - i.e. this will NOT work on MK3-row of machines, so do not even attempt to use it unless you are willing to backport the changes to the 8bit printer's FW.

Hence the increased version of the MMU FW to 3.0.4.

The key ideas:
- loading to nozzle: disengaging the Idler can happen while the printer is already pushing fillament down the nube
- unloading: MMU can prepare the Idler into an intermediate position and start pulling as soon as the FSensor turns off
- obviously, the unit tests had to be changed to reflect new behaviour

Some optimizations added to save space:
- registers: dropped support for reading/writing raw memory areas, it hasn't been used (almost)
- unified common LED behaviour into functions (that saved ~140B which is great)