### PR TITLE
Filament unload & ejection FIX

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -228,6 +228,16 @@ static constexpr U_deg idlerIntermediateSlotPositions[toolCount + 1] = {
     IdlerOffsetFromHome ///18.0_deg Fully disengaged all slots
 };
 
+/// Intermediate positions for Idler's slots: Unloading version to fix the stuck filament
+static constexpr U_deg idlerIntermediateUnloadSlotPositions[toolCount + 1] = {
+    IdlerOffsetFromHome + 4.25F * IdlerSlotDistance,
+    IdlerOffsetFromHome + 3.25F * IdlerSlotDistance,
+    IdlerOffsetFromHome + 2.25F * IdlerSlotDistance,
+    IdlerOffsetFromHome + 1.25F * IdlerSlotDistance,
+    IdlerOffsetFromHome + 0.25F * IdlerSlotDistance,
+    IdlerOffsetFromHome ///18.0_deg Fully disengaged all slots
+};
+
 static constexpr U_deg idlerParkPositionDelta = -IdlerSlotDistance + 5.0_deg / 2; // TODO verify
 
 static constexpr U_deg_s idlerFeedrate = 300._deg_s;

--- a/src/logic/unload_to_finda.cpp
+++ b/src/logic/unload_to_finda.cpp
@@ -20,7 +20,7 @@ void UnloadToFinda::Reset(uint8_t maxTries) {
     } else {
         // FINDA is sensing the filament, plan moves to unload it
         state = EngagingIdler;
-        mi::idler.PartiallyDisengage(mg::globals.ActiveSlot()); // basically prepare before the active slot - saves ~1s
+        mi::idler.PartiallyEngage(mg::globals.ActiveSlot()); // basically prepare before the active slot - saves ~1s
         started_ms = mt::timebase.Millis();
         ml::leds.ActiveSlotProcessing();
     }
@@ -34,7 +34,7 @@ bool UnloadToFinda::Step() {
     // It will not wait for the extruder to finish the relieve move.
     // However, such an approach breaks running the MMU on a non-reworked MK4/C1, which hasn't been officially supported, but possible (with some level of uncertainity).
     case EngagingIdler:
-        if (!mi::idler.PartiallyDisengaged()) { // just waiting for Idler to get into the target intermediate position
+        if (!mi::idler.PartiallyEngaged()) { // just waiting for Idler to get into the target intermediate position
             return false;
         }
         if (mfs::fsensor.Pressed()) { // still pressed, printer didn't free the filament yet

--- a/src/modules/idler.cpp
+++ b/src/modules/idler.cpp
@@ -13,9 +13,12 @@ namespace idler {
 Idler idler;
 
 void Idler::PrepareMoveToPlannedSlot() {
-    mm::motion.PlanMoveTo<mm::Idler>(
-        plannedMove == Operation::engage ? SlotPosition(plannedSlot) : IntermediateSlotPosition(plannedSlot),
-        mm::unitToAxisUnit<mm::I_speed_t>(mg::globals.IdlerFeedrate_deg_s()));
+    mm::motion.PlanMoveTo<mm::Idler>(plannedMove == Operation::engage
+        ? SlotPosition(plannedSlot)
+        : plannedMove == Operation::intermediateUnload
+            ? IntermediateUnloadSlotPosition(plannedSlot)
+            : IntermediateSlotPosition(plannedSlot),
+    mm::unitToAxisUnit<mm::I_speed_t>(mg::globals.IdlerFeedrate_deg_s()));
     dbg_logic_fP(PSTR("Prepare Move Idler slot %d"), plannedSlot);
 }
 
@@ -78,6 +81,10 @@ Idler::OperationResult Idler::PartiallyDisengage(uint8_t slot) {
 
 Idler::OperationResult Idler::Engage(uint8_t slot) {
     return PlanMoveInner(slot, Operation::engage);
+}
+
+Idler::OperationResult Idler::PartiallyEngage(uint8_t slot) {
+    return PlanMoveInner(slot, Operation::intermediateUnload);
 }
 
 Idler::OperationResult Idler::PlanMoveInner(uint8_t slot, Operation plannedOp) {

--- a/src/modules/idler.h
+++ b/src/modules/idler.h
@@ -25,6 +25,10 @@ public:
     /// @note if(state==OnHold) all attempts to Engage are rejected with OperationResult::Rejected
     OperationResult Engage(uint8_t slot);
 
+    /// Plan partial engaging of the idler
+    /// @returns #OperationResult
+    OperationResult PartiallyEngage(uint8_t slot);
+
     /// Plan disengaging of the idler, i.e. parking the idler
     /// @returns #OperationResult
     /// @note if(state==OnHold) all attempts to Disengage are rejected with OperationResult::Rejected
@@ -44,6 +48,7 @@ public:
     inline bool Engaged() const { return currentlyEngaged == Operation::engage; }
     inline bool Disengaged() const { return currentlyEngaged == Operation::disengage; }
     inline bool PartiallyDisengaged() const { return currentlyEngaged == Operation::intermediate; }
+    inline bool PartiallyEngaged() const { return currentlyEngaged == Operation::intermediateUnload; }
 
     /// @returns predefined positions of individual slots
     static constexpr mm::I_pos_t SlotPosition(uint8_t slot) {
@@ -53,6 +58,11 @@ public:
     /// @returns predefined intermediate positions between individual slots
     static constexpr mm::I_pos_t IntermediateSlotPosition(uint8_t slot) {
         return mm::unitToAxisUnit<mm::I_pos_t>(config::idlerIntermediateSlotPositions[slot]);
+    }
+
+    /// @returns predefined intermediate positions between individual slots (Unload)
+    static constexpr mm::I_pos_t IntermediateUnloadSlotPosition(uint8_t slot) {
+    return mm::unitToAxisUnit<mm::I_pos_t>(config::idlerIntermediateUnloadSlotPositions[slot]);
     }
 
     /// @returns the index of idle position of the idler, usually 5 in case of 0-4 valid indices of filament slots
@@ -76,7 +86,8 @@ private:
     enum class Operation : uint8_t {
         disengage = 0,
         engage = 1,
-        intermediate = 2 ///< planned movement will be to an intermediate position between slots (different array of positions)
+        intermediate = 2, ///< planned movement will be to an intermediate position between slots (different array of positions)
+        intermediateUnload = 3 ///Reduced movement to prevent filament stuck
     };
 
     OperationResult PlanMoveInner(uint8_t slot, Operation plannedOp);


### PR DESCRIPTION
### What does this release fix?

**1) Filament stuck during unloading:**

Added an idler position setting to prevent premature filament compression.
PartiallyDisengage modified to use this setting and become PartiallyEngage.
It makes more sense and works perfectly without the filament getting stuck.

**2) Filament ejection from the MMU during the print:**

Removed the Commit https://github.com/prusa3d/Prusa-Firmware-MMU/commit/9e3b300b2e5bbbd5c9b8cb90110b10ee9539abff which causes the ejection of the adjacent filament adjacent to the current slot.
This issue happening because the small move before pulling disengage the adjacent filament.